### PR TITLE
Ruby function splat args return arity of -1

### DIFF
--- a/lib/stimulus_reflex/channel.rb
+++ b/lib/stimulus_reflex/channel.rb
@@ -47,7 +47,7 @@ class StimulusReflex::Channel < ActionCable::Channel::Base
   def delegate_call_to_reflex(reflex, method_name, arguments = [])
     instrument_payload = {reflex: reflex.class.name, method_name: method_name, arguments: arguments.inspect}
     ActiveSupport::Notifications.instrument "delegate_call.stimulus_reflex", instrument_payload do
-      if reflex.method(method_name).arity <> 0
+      if reflex.method(method_name).arity != 0
         reflex.send method_name, *arguments
       else
         reflex.send method_name

--- a/lib/stimulus_reflex/channel.rb
+++ b/lib/stimulus_reflex/channel.rb
@@ -47,7 +47,7 @@ class StimulusReflex::Channel < ActionCable::Channel::Base
   def delegate_call_to_reflex(reflex, method_name, arguments = [])
     instrument_payload = {reflex: reflex.class.name, method_name: method_name, arguments: arguments.inspect}
     ActiveSupport::Notifications.instrument "delegate_call.stimulus_reflex", instrument_payload do
-      if reflex.method(method_name).arity > 0
+      if reflex.method(method_name).arity <> 0
         reflex.send method_name, *arguments
       else
         reflex.send method_name


### PR DESCRIPTION
I wasn't sure why I could specify an argument in my Reflex function, but it turns out a Ruby function with *args has arity -1, which means that you're actually sending a splat in but the end user developer must specify a specific number of arguments to receive.

This is not my primary area of expertise, but I am working on the assumption that this was an oversight. If there's a good reason to not encourage the use of splat arguments, I'd love to learn.