### PR TITLE
Add support for room param to facilitate per-session broadcasts

### DIFF
--- a/lib/stimulus_reflex/channel.rb
+++ b/lib/stimulus_reflex/channel.rb
@@ -12,7 +12,7 @@ class StimulusReflex::Channel < ActionCable::Channel::Base
     ids = connection.identifiers.map { |identifier|
       send(identifier).try(:id)
     }
-    "#{channel_name}#{ids.join ":"}"
+    "#{channel_name}#{ids.join ":"}#{params[:room]}"
   end
 
   def subscribed


### PR DESCRIPTION
If there are no connection identifiers in use, broadcasts will be sent to all connected clients. Since the params hash returns empty strings as default values, there's no harm in adding a check for the room parameter, which is a common convention in Action Cable development.

In my proposed changes to stimulus_reflex.js, I check the document head for a meta tag called session, which I pack with the session.id in the application layout.