### PR TITLE
Add Ruby magic comment

### DIFF
--- a/lib/stimulus_reflex.rb
+++ b/lib/stimulus_reflex.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "uri"
 require "rack"
 require "rails/engine"

--- a/lib/stimulus_reflex/channel.rb
+++ b/lib/stimulus_reflex/channel.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class StimulusReflex::Channel < ActionCable::Channel::Base
   include CableReady::Broadcaster
 

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class StimulusReflex::Reflex
   attr_reader :channel, :url
 

--- a/lib/stimulus_reflex/version.rb
+++ b/lib/stimulus_reflex/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module StimulusReflex
   VERSION = "1.0.2"
 end


### PR DESCRIPTION
Add `# frozen_string_literal: true` comment at the top of the ruby files.
It's a free performance and convention inside the Rails itself.