### PR TITLE
Add support for declarative stimulus/reflex behavior

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    stimulus_reflex (1.1.1)
+    stimulus_reflex (2.0.0)
       cable_ready (>= 4.0.3)
       nokogiri
       rack

--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ _Inspired by [Phoenix LiveView](https://youtu.be/Z2DU0qLfPIY?t=670)._ 🙌
     + [app/reflexes/example_reflex.rb](#appreflexesexample_reflexrb-1)
 - [What Just Happened](#what-just-happened)
 - [Advanced Usage](#advanced-usage)
-  * [Reflex Methods](#reflex-methods)
-    + [The Reflex `element` property](#the-reflex-element-property)
+  * [The Reflex `element` property](#the-reflex-element-property)
   * [ActionCable](#actioncable)
     + [Performance](#performance)
     + [ActionCable Rooms](#actioncable-rooms)
@@ -197,9 +196,7 @@ The following happens when a `StimulusReflex::Reflex` is invoked.
 
 ## Advanced Usage
 
-### Reflex Methods
-
-#### The Reflex `element` property
+### The Reflex `element` property
 
 All reflex methods expose an `element` property.
 This property holds a Hash like data structure that represents the HTML element that triggered the refelx.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Lines of Code](http://img.shields.io/badge/lines_of_code-203-brightgreen.svg?style=flat)](http://blog.codinghorror.com/the-best-code-is-no-code-at-all/)
+[![Lines of Code](http://img.shields.io/badge/lines_of_code-218-brightgreen.svg?style=flat)](http://blog.codinghorror.com/the-best-code-is-no-code-at-all/)
 [![Maintainability](https://api.codeclimate.com/v1/badges/2b24fdbd1ae37a24bedb/maintainability)](https://codeclimate.com/github/hopsoft/stimulus_reflex/maintainability)
 
 # StimulusReflex

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ end
 
 The code above will automatically update the relevant DOM nodes with the updated count whenever the anchor is clicked.
 
-__Note that all concerns from managing state to rendering views is handled on the server side.__
+__Note that all concerns from managing state to rendering views are handled server side.__
 This technique works regardless of how complex the UI may become.
 For example, we could render multiple instances of `@count` in unrelated sections of the page and they will all update.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ _Inspired by [Phoenix LiveView](https://youtu.be/Z2DU0qLfPIY?t=670)._ 🙌
   * [app/reflexes/example_reflex.rb](#appreflexesexample_reflexrb)
 - [Advanced Usage](#advanced-usage)
   * [Reflex Methods](#reflex-methods)
-    + [The `options` Keyword Argument](#the-options-keyword-argument)
+    + [The Reflex `element` property](#the-reflex-element-property)
   * [ActionCable](#actioncable)
     + [Performance](#performance)
     + [ActionCable Rooms](#actioncable-rooms)
@@ -136,55 +136,45 @@ The following happens after the `StimulusReflex::Reflex` method call finishes.
 
 ### Reflex Methods
 
-#### The `options` Keyword Argument
+#### The Reflex `element` property
 
-Reflex methods support an _optional_ `options` keyword argument.
-
-- This is the only supported keyword argument.
-- It must appear after ordinal arguments.
-
-```ruby
-class ExampleReflex < StimulusReflex::Reflex
-  def work(options: {})
-    # ...
-  end
-
-  def other_work(value, options: {})
-    # ...
-  end
-end
-```
-
-The `options` value contains all of the Stimulus controller's
+All reflex methods expose an `element` property.
+This property holds a Hash like data structure that represents the HTML element that triggered the refelx.
+It contains all of the Stimulus controller's
 [DOM element attributes](https://developer.mozilla.org/en-US/docs/Web/API/Element/attributes) as well as other properties like `checked` and `value`.
 _Most of the values will be strings._
-Here's an example:
 
 ```html
-<checkbox checked label="Example" data-controller="checkbox" data-value="123" />
+<checkbox id="example"
+          label="Example"
+          data-controller="checkbox"
+          data-value="123"
+          checked />
 ```
-
-The markup above produces the following behavior in a reflex method.
 
 ```ruby
 class ExampleReflex < StimulusReflex::Reflex
-  def work(options: {})
-    options[:checked]            # => true
-    options[:label]              # => "Example"
-    options["data-controller"]   # => "checkbox"
-    options["data-value"]        # => "123"
-    options.dataset[:controller] # => "checkbox"
-    options.dataset[:value]      # => "123"
+  def work()
+    element[:id]    # => the HTML element's id attribute value
+    element.dataset # => a Hash that represents the HTML element's dataset
+
+    element[:id]                 # => "example"
+    element[:checked]            # => true
+    element[:label]              # => "Example"
+    element["data-controller"]   # => "checkbox"
+    element["data-value"]        # => "123"
+    element.dataset[:controller] # => "checkbox"
+    element.dataset[:value]      # => "123"
   end
 end
 ```
 
-- `options[:checked]` holds a boolean
-- `options[:selected]` holds a boolean
-- `options[:value]` holds the [DOM element's value](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#value)
-- `select` elements assign `options[:value]` to their selected option's value
-- `select` elements with _multiselect_ enabled assign `options[:values]` to their selected options values
-- All other values stored in `options` are extracted from the DOM element's attributes
+- `element[:checked]` holds a boolean
+- `element[:selected]` holds a boolean
+- `element[:value]` holds the [DOM element's value](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#value)
+- `select` elements assign `element[:value]` to their selected option's value
+- `select` elements with _multiselect_ enabled assign `element[:values]` to their selected options values
+- All other values exposed in `element` are extracted from the DOM element's attributes
 
 ### ActionCable
 

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "actioncable": ">= 5.2",
     "cable_ready": ">= 4.0.3",
-    "stimulus": "^1.1.1"
+    "stimulus": ">= 1.1.1"
   },
   "devDependencies": {
     "prettier": "^1.18.2"

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -13,7 +13,8 @@
   "license": "MIT",
   "dependencies": {
     "actioncable": ">= 5.2",
-    "cable_ready": ">= 4.0.3"
+    "cable_ready": ">= 4.0.3",
+    "stimulus": "^1.1.1"
   },
   "devDependencies": {
     "prettier": "^1.18.2"

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -94,10 +94,13 @@ application.register('stimulus-reflex', StimulusReflexController);
 
 const init = () => {
   document.querySelectorAll('[data-reflex]').forEach(el => {
-    if (String(el.getAttribute('data-controller')).indexOf('stimulus-reflex') >= 0) return;
-    el.setAttribute('data-controller', `stimulus-reflex`);
-    const actions = el.dataset.reflex.split(' ').map(reflex => {
-      return `${reflex.split('->')[0]}->stimulus-reflex#perform`;
+    if (String(el.dataset.controller).indexOf('stimulus-reflex') >= 0) return;
+    const controllers = el.dataset.controller ? el.dataset.controller.split(' ') : [];
+    const actions = el.dataset.action ? el.dataset.action.split(' ') : [];
+    controllers.push('stimulus-reflex');
+    el.setAttribute('data-controller', controllers.join(' '));
+    el.dataset.reflex.split(' ').forEach(reflex => {
+      actions.push(`${reflex.split('->')[0]}->stimulus-reflex#perform`);
     });
     el.setAttribute('data-action', actions.join(' '));
   });

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -94,7 +94,7 @@ application.register('stimulus-reflex', StimulusReflexController);
 
 const init = () => {
   document.querySelectorAll('[data-stimulus][data-reflex]').forEach(el => {
-    if (el.hasAttribute('data-controller')) return;
+    if (String(el.getAttribute('data-controller')).indexOf('stimulus-reflex') >= 0) return;
     el.setAttribute('data-controller', `stimulus-reflex`);
     const actions = el.dataset.stimulus.split(' ').map(stimulus => {
       return `${stimulus}->stimulus-reflex#perform`;

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -81,10 +81,11 @@ class StimulusReflexController extends Controller {
   connect() {
     register(this);
   }
+
   perform(event) {
     event.preventDefault();
     event.stopPropagation();
-    this.stimulate(this.element.dataset.reflex);
+    this.element.dataset.reflex.split(' ').forEach(reflex => this.stimulate(this.element.dataset.reflex));
   }
 }
 
@@ -93,9 +94,12 @@ application.register('stimulus-reflex', StimulusReflexController);
 
 const init = () => {
   document.querySelectorAll('[data-stimulus][data-reflex]').forEach(el => {
-    if (!el.hasAttribute('data-action'))
-      el.setAttribute('data-action', `${el.dataset.stimulus}->stimulus-reflex#perform`);
-    if (!el.hasAttribute('data-controller')) el.setAttribute('data-controller', `stimulus-reflex`);
+    if (el.hasAttribute('data-controller')) return;
+    el.setAttribute('data-controller', `stimulus-reflex`);
+    const actions = el.dataset.stimulus.split(' ').map(stimulus => {
+      return `${stimulus}->stimulus-reflex#perform`;
+    });
+    el.setAttribute('data-action', actions.join(' '));
   });
 };
 

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -85,7 +85,7 @@ class StimulusReflexController extends Controller {
   perform(event) {
     event.preventDefault();
     event.stopPropagation();
-    this.element.dataset.reflex.split(' ').forEach(reflex => this.stimulate(this.element.dataset.reflex));
+    this.element.dataset.reflex.split(' ').forEach(reflex => this.stimulate(reflex.split('->')[1]));
   }
 }
 
@@ -93,11 +93,11 @@ const application = Application.start();
 application.register('stimulus-reflex', StimulusReflexController);
 
 const init = () => {
-  document.querySelectorAll('[data-stimulus][data-reflex]').forEach(el => {
+  document.querySelectorAll('[data-reflex]').forEach(el => {
     if (String(el.getAttribute('data-controller')).indexOf('stimulus-reflex') >= 0) return;
     el.setAttribute('data-controller', `stimulus-reflex`);
-    const actions = el.dataset.stimulus.split(' ').map(stimulus => {
-      return `${stimulus}->stimulus-reflex#perform`;
+    const actions = el.dataset.reflex.split(' ').map(reflex => {
+      return `${reflex.split('->')[0]}->stimulus-reflex#perform`;
     });
     el.setAttribute('data-action', actions.join(' '));
   });

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -106,9 +106,12 @@ const init = () => {
   });
 };
 
-window.addEventListener('load', init);
-document.addEventListener('turbolinks:load', init);
-document.addEventListener('cable-ready:after-morph', init);
+if (!document.stimulusReflexInitialized) {
+  document.stimulusReflexInitialized = true;
+  window.addEventListener('load', init);
+  document.addEventListener('turbolinks:load', init);
+  document.addEventListener('cable-ready:after-morph', init);
+}
 // End declarative stimulus/reflex behavior ................................................................
 
 export default { register };

--- a/javascript/stimulus_reflex_controller.js
+++ b/javascript/stimulus_reflex_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from 'stimulus';
+
+export default class extends Controller {
+  connect() {
+    this.constructor.register(this);
+  }
+
+  perform(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    this.element.dataset.reflex.split(' ').forEach(reflex => this.stimulate(reflex.split('->')[1]));
+  }
+}

--- a/javascript/yarn.lock
+++ b/javascript/yarn.lock
@@ -2,6 +2,30 @@
 # yarn lockfile v1
 
 
+"@stimulus/core@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@stimulus/core/-/core-1.1.1.tgz#42b0cfe5b73ca492f41de64b77a03980bae92c82"
+  integrity sha512-PVJv7IpuQx0MVPCBblXc6O2zbCmU8dlxXNH4bC9KK6LsvGaE+PCXXrXQfXUwAsse1/CmRu/iQG7Ov58himjiGg==
+  dependencies:
+    "@stimulus/mutation-observers" "^1.1.1"
+
+"@stimulus/multimap@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@stimulus/multimap/-/multimap-1.1.1.tgz#b95e3fd607345ab36e5d5b55486ee1a12d56b331"
+  integrity sha512-26R1fI3a8uUj0WlMmta4qcfIQGlagegdP4PTz6lz852q/dXlG6r+uPS/bx+H8GtfyS+OOXVr3SkZ0Zg0iRqRfQ==
+
+"@stimulus/mutation-observers@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@stimulus/mutation-observers/-/mutation-observers-1.1.1.tgz#0f6c6f081308427fed2a26360dda0c173b79cfc0"
+  integrity sha512-/zCnnw1KJlWO2mrx0yxYaRFZWMGnDMdOgSnI4hxDLxdWVuL2HMROU8FpHWVBLjKY3T9A+lGkcrmPGDHF3pfS9w==
+  dependencies:
+    "@stimulus/multimap" "^1.1.1"
+
+"@stimulus/webpack-helpers@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@stimulus/webpack-helpers/-/webpack-helpers-1.1.1.tgz#eff60cd4e58b921d1a2764dc5215f5141510f2c2"
+  integrity sha512-XOkqSw53N9072FLHvpLM25PIwy+ndkSSbnTtjKuyzsv8K5yfkFB2rv68jU1pzqYa9FZLcvZWP4yazC0V38dx9A==
+
 "actioncable@>= 5.2":
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/actioncable/-/actioncable-5.2.3.tgz#639d98855b854b7bfe2059ab97d6e0ae8fd60a1d"
@@ -23,3 +47,11 @@ prettier@^1.18.2:
   version "1.18.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
   integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+
+stimulus@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/stimulus/-/stimulus-1.1.1.tgz#53c2fded6849e7b85eed3ed8dd76e33abd74bec5"
+  integrity sha512-R0mBqKp48YnRDZOxZ8hiOH4Ilph3Yj78CIFTBkCwyHs4iGCpe7xlEdQ7cjIxb+7qVCSxFKgxO+mAQbsNgt/5XQ==
+  dependencies:
+    "@stimulus/core" "^1.1.1"
+    "@stimulus/webpack-helpers" "^1.1.1"

--- a/javascript/yarn.lock
+++ b/javascript/yarn.lock
@@ -48,7 +48,7 @@ prettier@^1.18.2:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
   integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
 
-stimulus@^1.1.1:
+"stimulus@>= 1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stimulus/-/stimulus-1.1.1.tgz#53c2fded6849e7b85eed3ed8dd76e33abd74bec5"
   integrity sha512-R0mBqKp48YnRDZOxZ8hiOH4Ilph3Yj78CIFTBkCwyHs4iGCpe7xlEdQ7cjIxb+7qVCSxFKgxO+mAQbsNgt/5XQ==

--- a/lib/stimulus_reflex.rb
+++ b/lib/stimulus_reflex.rb
@@ -10,7 +10,7 @@ require "nokogiri"
 require "cable_ready"
 require "stimulus_reflex/version"
 require "stimulus_reflex/reflex"
-require "stimulus_reflex/dom_element"
+require "stimulus_reflex/element"
 require "stimulus_reflex/channel"
 
 module StimulusReflex

--- a/lib/stimulus_reflex/channel.rb
+++ b/lib/stimulus_reflex/channel.rb
@@ -22,11 +22,11 @@ class StimulusReflex::Channel < ActionCable::Channel::Base
     reflex_name, method_name = target.split("#")
     reflex_name = reflex_name.classify
     arguments = data["args"] || []
-    options = StimulusReflex::DomElement.new(data["attrs"])
+    element = StimulusReflex::Element.new(data["attrs"])
 
     begin
-      reflex = reflex_name.constantize.new(self, url: url)
-      delegate_call_to_reflex reflex, method_name, arguments, options
+      reflex = reflex_name.constantize.new(self, url: url, element: element)
+      delegate_call_to_reflex reflex, method_name, arguments
     rescue => invoke_error
       logger.error "\e[31mStimulusReflex::Channel Failed to invoke #{target}! #{url} #{invoke_error}\e[0m"
     end
@@ -40,24 +40,15 @@ class StimulusReflex::Channel < ActionCable::Channel::Base
 
   private
 
-  def delegate_call_to_reflex(reflex, method_name, arguments = [], options = {})
+  def delegate_call_to_reflex(reflex, method_name, arguments = [])
     method = reflex.method(method_name)
     required_params = method.parameters.select { |(kind, _)| kind == :req }
     optional_params = method.parameters.select { |(kind, _)| kind == :opt }
-    accepts_options_kwarg = method.parameters.select { |(kind, name)| name == :options && kind.to_s.start_with?("key") }.size > 0
 
     if arguments.size == 0 && required_params.size == 0
-      if accepts_options_kwarg
-        reflex.public_send method_name, {options: options}
-      else
-        reflex.public_send method_name
-      end
+      reflex.public_send method_name
     elsif arguments.size >= required_params.size && arguments.size <= required_params.size + optional_params.size
-      if accepts_options_kwarg
-        reflex.public_send method_name, *arguments, {options: options}
-      else
-        reflex.public_send method_name, *arguments
-      end
+      reflex.public_send method_name, *arguments
     else
       raise ArgumentError.new("wrong number of arguments (given #{arguments.inspect}, expected #{required_params.inspect}, optional #{optional_params.inspect})")
     end

--- a/lib/stimulus_reflex/element.rb
+++ b/lib/stimulus_reflex/element.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class StimulusReflex::DomElement
+class StimulusReflex::Element
   attr_reader :attributes
 
   delegate :[], to: :"@attributes"

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
 class StimulusReflex::Reflex
-  attr_reader :channel, :url
+  attr_reader :channel, :url, :element
 
   delegate :connection, to: :channel
   delegate :session, to: :request
 
-  def initialize(channel, url: nil)
+  def initialize(channel, url: nil, element: nil)
     @channel = channel
     @url = url
+    @element = element
   end
 
   def request

--- a/lib/stimulus_reflex/version.rb
+++ b/lib/stimulus_reflex/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module StimulusReflex
-  VERSION = "1.1.1"
+  VERSION = "2.0.0"
 end


### PR DESCRIPTION
Add declarative stimulus/reflex behavior via data attributes.

- `data-reflex` - accepts a Stimulus styled value to specify DOM event & server side reflexes i.e. `click->ExampleReflex#method`

Very much inspired by #12

Example usage here: https://github.com/hopsoft/stimulus_reflex_todomvc/pull/16

I have a question out to the Stimulus team to determine if the techniques used here are valid. i.e. calling `application.start` inside a library. https://github.com/stimulusjs/stimulus/issues/272