### PR TITLE
update github action triggers

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,8 +1,12 @@
-name: Run Prettier Lints
+name: Prettier Check Action
 
 on:
-  - push
-  - pull_request
+  pull_request:
+    branches:
+      - '*'
+  push:
+    branches:
+      - master
 
 jobs:
   prettier:

--- a/.github/workflows/standardrb.yml
+++ b/.github/workflows/standardrb.yml
@@ -1,8 +1,12 @@
-name: Run Standard Lints
+name: StandardRB Check Action
 
 on:
-  - push
-  - pull_request
+  pull_request:
+    branches:
+      - '*'
+  push:
+    branches:
+      - master
 
 jobs:
   standard:
@@ -10,11 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - name: Bundle
-      uses: CultureHQ/actions-bundler@master
-      with:
-        args: install
     - name: Standard
       uses: CultureHQ/actions-bundler@master
       with:
-        args: exec standardrb --format progress
+        args: install && bundle exec standardrb --format progress

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![Lines of Code](http://img.shields.io/badge/lines_of_code-203-brightgreen.svg?style=flat)](http://blog.codinghorror.com/the-best-code-is-no-code-at-all/)
 [![Maintainability](https://api.codeclimate.com/v1/badges/2b24fdbd1ae37a24bedb/maintainability)](https://codeclimate.com/github/hopsoft/stimulus_reflex/maintainability)
+![Prettier](https://github.com/hopsoft/stimulus_reflex/workflows/Prettier%20Check%20Action/badge.svg)
+![StandardRB](https://github.com/hopsoft/stimulus_reflex/workflows/StandardRB%20Check%20Action/badge.svg)
 
 # StimulusReflex
 


### PR DESCRIPTION
Update the triggers so this only runs on pull request triggers.

Currently, if a user has commit access to a repo, the lint actions will run twice. This is because GitHub triggers to events. 

1. There is a push event on the repo. Only users with commit access can trigger these. 
2. There is a pull request event on the repo. As it stands, this seems to only trigger on pushes to the repo. 

With this update, actions will run on all PR's, and only run push lints when you push to master.

Changes to the StandardRB action should speed up that action.

NOTE: the badges do not appear to render correctly in the diff - see here for example: https://github.com/andrewmcodes/stimulus_reflex

Added badges for flair - happy to remove if you don't like them. [docs](https://help.github.com/en/articles/configuring-a-workflow#adding-a-workflow-status-badge-to-your-repository)