### PR TITLE
add .vscode directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /spec/reports/
 /tmp/
 node_modules
+.vscode


### PR DESCRIPTION
# Enhancement

## Description

Add `.vscode` directory to the `.gitignore`.

## Why should this be added

When we add editor configurations, this will make it easier to avoid accidentally getting someone's workspace settings committed if they have not added it to their global git ignore.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier) are passing