### PR TITLE
add test action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Prettier
+name: Test
 
 on:
   pull_request:
@@ -10,15 +10,18 @@ on:
 
 jobs:
   prettier:
-    name: Prettier Check Action
+    name: Test Action
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [10, 12]
     steps:
     - uses: actions/checkout@master
     - name: Setup Node
       uses: actions/setup-node@v1
       with:
-        version: '12.x'
+        node-version: ${{ matrix.node }}
     - run: yarn
       working-directory: javascript/
-    - run: yarn run prettier-check
+    - run: yarn run test
       working-directory: javascript/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,8 @@ on:
       - master
 
 jobs:
-  prettier:
-    name: Test Action
+  javascript_test:
+    name: JavaScript Test Action
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Tests
 
 on:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/2b24fdbd1ae37a24bedb/maintainability)](https://codeclimate.com/github/hopsoft/stimulus_reflex/maintainability)
 ![Prettier](https://github.com/hopsoft/stimulus_reflex/workflows/Prettier/badge.svg)
 ![StandardRB](https://github.com/hopsoft/stimulus_reflex/workflows/StandardRB/badge.svg)
+![Tests](https://github.com/hopsoft/stimulus_reflex/workflows/Tests/badge.svg)
 
 # StimulusReflex
 


### PR DESCRIPTION
# Enhancement

## Description

Add GitHub action to run tests. Currently running against node 10 and 12, but we can choose to run one or the other if needed.

## Why should this be added

This allows for an easy way to confirm tests are passing on branches and pushes to master. Currently we only have JavaScript tests, but this action can be easily configured to add another job for running Ruby tests in the future.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier) are passing
