### PR TITLE
update readme to indicate use of prettier-standard

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,4 +13,4 @@ Explain value.
 ## Checklist
 
 - [ ] My code follows the style guidelines of this project
-- [ ] Checks (StandardRB & Prettier) are passing
+- [ ] Checks (StandardRB & Prettier-Standard) are passing

--- a/.github/workflows/prettier-standard.yml
+++ b/.github/workflows/prettier-standard.yml
@@ -1,4 +1,4 @@
-name: Prettier
+name: Prettier-Standard
 
 on:
   pull_request:
@@ -10,7 +10,7 @@ on:
 
 jobs:
   prettier:
-    name: Prettier Check Action
+    name: Prettier-Standard Check Action
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
@@ -20,5 +20,5 @@ jobs:
         version: '12.x'
     - run: yarn
       working-directory: javascript/
-    - run: yarn run prettier-check
+    - run: yarn run prettier-standard-check
       working-directory: javascript/

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Everyone interacting with StimulusReflex is expected to follow the [Code of Cond
 ### Coding Standards
 
 This project uses [Standard](https://github.com/testdouble/standard)
-and [Prettier](https://github.com/prettier/prettier) to minimize bike shedding related to code formatting.
+and [prettier-standard](https://github.com/sheerun/prettier-standard) to minimize bike shedding related to code formatting.
+
 Please run `./bin/standardize` prior submitting pull requests.
 
 View the [wiki](https://github.com/hopsoft/stimulus_reflex/wiki/Editor-Configuration) to see recommendations for configuring your editor to work best with the project.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Lines of Code](http://img.shields.io/badge/lines_of_code-375-brightgreen.svg?style=flat)](http://blog.codinghorror.com/the-best-code-is-no-code-at-all/)
 [![Maintainability](https://api.codeclimate.com/v1/badges/2b24fdbd1ae37a24bedb/maintainability)](https://codeclimate.com/github/hopsoft/stimulus_reflex/maintainability)
-![Prettier](https://github.com/hopsoft/stimulus_reflex/workflows/Prettier/badge.svg)
+![Prettier-Standard](https://github.com/hopsoft/stimulus_reflex/workflows/Prettier-Standard/badge.svg)
 ![StandardRB](https://github.com/hopsoft/stimulus_reflex/workflows/StandardRB/badge.svg)
 ![Tests](https://github.com/hopsoft/stimulus_reflex/workflows/Tests/badge.svg)
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Everyone interacting with StimulusReflex is expected to follow the [Code of Cond
 ### Coding Standards
 
 This project uses [Standard](https://github.com/testdouble/standard)
-and [prettier-standard](https://github.com/sheerun/prettier-standard) to minimize bike shedding related to code formatting.
+and [Prettier-Standard](https://github.com/sheerun/prettier-standard) to minimize bike shedding related to code formatting.
 
 Please run `./bin/standardize` prior submitting pull requests.
 

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -4,7 +4,7 @@
   "main": "./stimulus_reflex.js",
   "scripts": {
     "test": "yarn run mocha --require @babel/register",
-    "prettier-check": "yarn run prettier-standard --check ./**/*.js"
+    "prettier-standard-check": "yarn run prettier-standard --check ./**/*.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Documentation

## Description

The README still indicates we are using `prettier`, this commit changes that to `prettier-standard`.

I have updated the wiki as well to show how to configure this in VSCode + a suggestion for the ruby settings thanks to @pjforde1978 

## Why should this be added

Keep the community correctly informed of our formatter of choice. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier) are passing
