### PR TITLE
abort reflex action if method returns false

### DIFF
--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -25,7 +25,7 @@ let application
 // - error
 // - after
 //
-const invokeLifecycleMethod = (stage, reflex, element) => {
+const invokeLifecycleMethod = (stage, reflex, element, returnValue) => {
   if (!element) return
 
   // traverse the DOM for a matching reflex controller
@@ -57,6 +57,7 @@ const invokeLifecycleMethod = (stage, reflex, element) => {
             controller,
             element,
             reflex,
+            returnValue,
             element.reflexError
           ),
         1
@@ -70,6 +71,7 @@ const invokeLifecycleMethod = (stage, reflex, element) => {
             controller,
             element,
             reflex,
+            returnValue,
             element.reflexError
           ),
         1
@@ -272,11 +274,12 @@ if (!document.stimulusReflexInitialized) {
   // to the source element in case it gets removed from the DOM via morph.
   // This is safe because the server side reflex completed successfully.
   document.addEventListener('cable-ready:before-morph', event => {
-    const { target, attrs, last } = event.detail.stimulusReflex || {}
+    const { target, attrs, last, returnValue } =
+      event.detail.stimulusReflex || {}
     if (!last) return
     const element = findElement(attrs)
-    invokeLifecycleMethod('success', target, element)
-    invokeLifecycleMethod('after', target, element)
+    invokeLifecycleMethod('success', target, element, returnValue)
+    invokeLifecycleMethod('after', target, element, returnValue)
   })
   document.addEventListener('stimulus-reflex:500', event => {
     const { target, attrs, error } = event.detail.stimulusReflex || {}

--- a/lib/stimulus_reflex/channel.rb
+++ b/lib/stimulus_reflex/channel.rb
@@ -30,7 +30,7 @@ class StimulusReflex::Channel < ActionCable::Channel::Base
       reflex_class = reflex_name.constantize
       raise ArgumentError.new("#{reflex_name} is not a StimulusReflex::Reflex") unless is_reflex?(reflex_class)
       reflex = reflex_class.new(self, url: url, element: element, selectors: selectors)
-      delegate_call_to_reflex reflex, method_name, arguments
+      return if delegate_call_to_reflex(reflex, method_name, arguments) == false
     rescue => invoke_error
       return broadcast_error("StimulusReflex::Channel Failed to invoke #{target}! #{url} #{invoke_error}", data)
     end

--- a/lib/stimulus_reflex/channel.rb
+++ b/lib/stimulus_reflex/channel.rb
@@ -31,7 +31,7 @@ class StimulusReflex::Channel < ActionCable::Channel::Base
       raise ArgumentError.new("#{reflex_name} is not a StimulusReflex::Reflex") unless is_reflex?(reflex_class)
       reflex = reflex_class.new(self, url: url, element: element, selectors: selectors)
       return_value = delegate_call_to_reflex(reflex, method_name, arguments)
-      return if return_value == false
+      return if reflex.abort
     rescue => invoke_error
       return broadcast_error("StimulusReflex::Channel Failed to invoke #{target}! #{url} #{invoke_error}", data)
     end

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class StimulusReflex::Reflex
-  attr_reader :channel, :url, :element, :selectors
+  attr_reader :channel, :url, :element, :selectors, :abort
 
   delegate :connection, to: :channel
   delegate :session, to: :request
@@ -11,9 +11,14 @@ class StimulusReflex::Reflex
     @url = url
     @element = element
     @selectors = selectors
+    @abort = false
   end
 
   def request
     @request ||= ActionDispatch::Request.new(connection.env)
+  end
+
+  def cancel_reflex!
+    @abort = true
   end
 end


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Enhancement

## Description

Allow developer to abort a reflex operation before rendering the template if the Reflex class method returns false. No ActionCable broadcast will be send, and no afterX callbacks will be fired.

## Why should this be added

Flexibility!

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
