### PR TITLE
Use application.js as fallback file path

### DIFF
--- a/lib/tasks/stimulus_reflex/install.rake
+++ b/lib/tasks/stimulus_reflex/install.rake
@@ -12,10 +12,10 @@ namespace :stimulus_reflex do
     FileUtils.mkdir_p Rails.root.join("app/reflexes"), verbose: true
 
     filepath = if File.exist? Rails.root.join("app/javascript/controllers/index.js")
-                 Rails.root.join("app/javascript/controllers/index.js")
-               else
-                 Rails.root.join("app/javascript/packs/application.js")
-               end
+      Rails.root.join("app/javascript/controllers/index.js")
+    else
+      Rails.root.join("app/javascript/packs/application.js")
+    end
     puts "Updating #{filepath}"
     lines = File.open(filepath, "r") { |f| f.readlines }
     import_line = lines.find { |line| line.start_with?("import StimulusReflex") }

--- a/lib/tasks/stimulus_reflex/install.rake
+++ b/lib/tasks/stimulus_reflex/install.rake
@@ -11,7 +11,11 @@ namespace :stimulus_reflex do
     FileUtils.mkdir_p Rails.root.join("app/javascript/controllers"), verbose: true
     FileUtils.mkdir_p Rails.root.join("app/reflexes"), verbose: true
 
-    filepath = Rails.root.join("app/javascript/controllers/index.js")
+    filepath = if File.exist? Rails.root.join("app/javascript/controllers/index.js")
+                 Rails.root.join("app/javascript/controllers/index.js")
+               else
+                 Rails.root.join("app/javascript/packs/application.js")
+               end
     puts "Updating #{filepath}"
     lines = File.open(filepath, "r") { |f| f.readlines }
     import_line = lines.find { |line| line.start_with?("import StimulusReflex") }


### PR DESCRIPTION
# Bug Fix PR

## Description

Use `application.js` as fallback file path.

Fixes #81 

## Why should this be added

To support earlier versions of https://github.com/rails/webpacker

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
