### PR TITLE
add actioncable connection status classes to document.body

### DIFF
--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -85,12 +85,21 @@ const invokeLifecycleMethod = (stage, reflex, element) => {
 const createSubscription = controller => {
   const { channel, room } = controller.StimulusReflex
   const id = `${channel}${room}`
-
   const subscription =
     app.StimulusReflex.subscriptions[id] ||
     app.StimulusReflex.consumer.subscriptions.create(
       { channel, room },
       {
+        connected: () =>
+          document.body.classList.replace(
+            'reflex-disconnected',
+            'reflex-connected'
+          ),
+        disconnected: () =>
+          document.body.classList.replace(
+            'reflex-connected',
+            'reflex-disconnected'
+          ),
         received: data => {
           if (!data.cableReady) return
           const urls = [
@@ -261,6 +270,7 @@ app.StimulusReflex.subscriptions = app.StimulusReflex.subscriptions || {}
 
 if (!document.stimulusReflexInitialized) {
   document.stimulusReflexInitialized = true
+  setTimeout(() => document.body.classList.add('reflex-disconnected'), 1)
   window.addEventListener('load', () => setTimeout(setupDeclarativeReflexes, 1))
   document.addEventListener('turbolinks:load', () =>
     setTimeout(setupDeclarativeReflexes, 1)


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Enhancement

## Description

ActionCable provides subscription callbacks for connected and disconnected states. [Borrowed a good idea from LiveView](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html#module-loading-state-and-errors) to map these states onto the document body as css classes which can be used to hide/reveal functionality that shouldn't be available unless the connection has been established. 

## Why should this be added

If you look at [this nasty insanity](https://github.com/hopsoft/stimulus_reflex_expo/blob/a4920b84460846936a0d19f5cba10c45257cf399/app/javascript/controllers/snake_controller.js#L7) you will see an excellent example of the code currently required to wait for the socket to connect. In fact, 40% of this controller exists to support this function, with [additional complexity in the view](https://github.com/hopsoft/stimulus_reflex_expo/blob/a4920b84460846936a0d19f5cba10c45257cf399/app/views/snakes/_demo.html.erb#L29).

All of this could be replaced by CSS selectors on the key elements that show and hide themselves depending on the classes present in the body element, which is a standard trick in every front-end developer's toolkit.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
