### PR TITLE
adding support for prepend and append

### DIFF
--- a/lib/stimulus_reflex/channel.rb
+++ b/lib/stimulus_reflex/channel.rb
@@ -107,6 +107,8 @@ class StimulusReflex::Channel < ActionCable::Channel::Base
         html: document.css(selector).inner_html,
         children_only: true,
         permanent_attribute_name: "data-reflex-permanent",
+        append_attribute_name: "data-reflex-append",
+        prepend_attribute_name: "data-reflex-prepend",
         stimulus_reflex: data.merge(last: selector == selectors.last)
       )
     end


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Enhancement

## Description

Adjacent to data-reflex-root, this PR adds the ability to mark a reflex-root element with either `data-reflex-append` or `data-reflex-prepend`. Inspired by [LiveView custom DOM patching](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html#module-custom-dom-patching).

Tandem PR with [Cable Ready PR 19](https://github.com/hopsoft/cable_ready/pull/19).

## Why should this be added

Highly useful for chat interfaces, newsfeeds and any application that maintains a cursor inside of a larger document.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
