### PR TITLE
specify data-reflex-allow on an input element to allow reflex operations

### DIFF
--- a/javascript/attributes.js
+++ b/javascript/attributes.js
@@ -113,6 +113,7 @@ const isTextInput = element => {
 export const receivedFocus = event => {
   const element = event.target
   if (!isTextInput(element)) return
+  if (element.hasAttribute('data-reflex-allow')) return
   element.reflexPermanent = element.hasAttribute('data-reflex-permanent')
   element.setAttribute('data-reflex-permanent', '')
 }


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Enhancement

## Description

Adds a `data-reflex-allow` attribute to the API, which can be put on an input element to opt-out of SSoT handling.

## Why should this be added

While I still strongly believe SSoT is the responsible default, scenarios do emerge when you need an escape hatch.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
