### PR TITLE
update the readme regarding the scope of the CoC

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ _Inspired by [Phoenix LiveView](https://youtu.be/Z2DU0qLfPIY?t=670)._ 🙌
 
 ### Code of Conduct
 
-Everyone interacting with StimulusReflex is expected to follow the [Code of Conduct](CODE_OF_CONDUCT.md)
+Everyone interacting with the StimulusReflex project’s codebases, issue trackers, chat rooms and forum is expected to follow the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ### Coding Standards
 


### PR DESCRIPTION
# Enhancement

## Description

Update the README regarding the scope of the CoC.

## Why should this be added

This ensures that contributors and people interacting with the project know that the scope of the CoC extends to Discord and Discourse. Asked for in https://github.com/hopsoft/stimulus_reflex/issues/90#issuecomment-549144143. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
