### PR TITLE
StimulusReflex::Channel - Error messages include stack trace info

### DIFF
--- a/lib/stimulus_reflex/channel.rb
+++ b/lib/stimulus_reflex/channel.rb
@@ -32,14 +32,14 @@ class StimulusReflex::Channel < ActionCable::Channel::Base
       reflex = reflex_class.new(self, url: url, element: element, selectors: selectors)
       delegate_call_to_reflex reflex, method_name, arguments
     rescue => invoke_error
-      message = invoke_error.backtrace.first
+      message = exception_message_with_backtrace(invoke_error)
       return broadcast_error("StimulusReflex::Channel Failed to invoke #{target}! #{url} #{message}", data)
     end
 
     begin
       render_page_and_broadcast_morph url, reflex, selectors, data
     rescue => render_error
-      message = render_error.backtrace.first
+      message = exception_message_with_backtrace(render_error)
       broadcast_error "StimulusReflex::Channel Failed to re-render #{url} #{message}", data
     end
   end
@@ -122,5 +122,9 @@ class StimulusReflex::Channel < ActionCable::Channel::Base
       detail: {stimulus_reflex: data.merge(error: message)}
     )
     cable_ready.broadcast
+  end
+
+  def exception_message_with_backtrace(exception)
+    "#{exception} #{exception.backtrace.first}"
   end
 end

--- a/lib/stimulus_reflex/channel.rb
+++ b/lib/stimulus_reflex/channel.rb
@@ -32,13 +32,15 @@ class StimulusReflex::Channel < ActionCable::Channel::Base
       reflex = reflex_class.new(self, url: url, element: element, selectors: selectors)
       delegate_call_to_reflex reflex, method_name, arguments
     rescue => invoke_error
-      return broadcast_error("StimulusReflex::Channel Failed to invoke #{target}! #{url} #{invoke_error}", data)
+      message = invoke_error.backtrace.first
+      return broadcast_error("StimulusReflex::Channel Failed to invoke #{target}! #{url} #{message}", data)
     end
 
     begin
       render_page_and_broadcast_morph url, reflex, selectors, data
     rescue => render_error
-      broadcast_error "StimulusReflex::Channel Failed to re-render #{url} #{render_error}", data
+      message = render_error.backtrace.first
+      broadcast_error "StimulusReflex::Channel Failed to re-render #{url} #{message}", data
     end
   end
 


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)
Feature enhancement

## Description
Adds line number and filename of the error to `StimulusReflex::Channel` error messages. Example:

```
StimulusReflex::Channel Failed to invoke MessagesReflex#mark_as_read! http://localhost:3000/ /myprojects/reflexchat/app/reflexes/messages_reflex.rb:51:in `mark_as_read'
```

## Why should this be added
It's hard to debug errors without a backtrace. After making this change I was a lot more productive.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] Checks (StandardRB & Prettier-Standard) are passing
