### PR TITLE
Squish HTML prior to sending over wire

### DIFF
--- a/lib/stimulus_reflex/channel.rb
+++ b/lib/stimulus_reflex/channel.rb
@@ -63,7 +63,7 @@ class StimulusReflex::Channel < ActionCable::Channel::Base
   end
 
   def render_page_and_broadcast_morph(url, reflex, selectors, data = {})
-    html = render_page(url, reflex)
+    html = render_page(url, reflex)&.squish
     broadcast_morphs selectors, data, html if html.present?
   end
 


### PR DESCRIPTION
# Enhancement

A minor performance enhancement that sends fewer bits over the wire.

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing