### PR TITLE
Support devise authenticated routes

### DIFF
--- a/lib/stimulus_reflex/channel.rb
+++ b/lib/stimulus_reflex/channel.rb
@@ -87,8 +87,7 @@ class StimulusReflex::Channel < ActionCable::Channel::Base
       )
     )
     url_params = Rails.application.routes.recognize_path_with_request(request, url, request.env[:extras] || {})
-    controller_class = "#{url_params[:controller]}_controller".classify.constantize
-    controller = controller_class.new
+    controller = request.controller_class.new
     controller.instance_variable_set :"@stimulus_reflex", true
     reflex.instance_variables.each do |name|
       controller.instance_variable_set name, reflex.instance_variable_get(name)

--- a/lib/stimulus_reflex/channel.rb
+++ b/lib/stimulus_reflex/channel.rb
@@ -71,10 +71,16 @@ class StimulusReflex::Channel < ActionCable::Channel::Base
 
   def render_page(url, reflex)
     uri = URI.parse(url)
+    query_hash = Rack::Utils.parse_nested_query(uri.query)
     request = ActionDispatch::Request.new(
       connection.env.merge(
-        Rack::MockRequest.env_for(url).merge(
+        Rack::MockRequest.env_for(uri.to_s).merge(
+          "rack.request.query_hash" => query_hash,
+          "rack.request.query_string" => uri.query,
+          "ORIGINAL_SCRIPT_NAME" => "",
           "ORIGINAL_FULLPATH" => uri.path,
+          Rack::SCRIPT_NAME => "",
+          Rack::PATH_INFO => uri.path,
           Rack::REQUEST_PATH => uri.path,
           Rack::QUERY_STRING => uri.query,
         )


### PR DESCRIPTION
# Fix

## Description

Simplify how the request is reconstructed.
Also use the request when parsing the URL.

This change supports Devise authenticated routes.

Fixes #104

Related https://stimulus-reflex.discourse.group/t/cannot-get-sr-with-devise-to-work/14

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing