### PR TITLE
More defense in the received handler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
     nokogiri (1.10.7)
       mini_portile2 (~> 2.4.0)
     parallel (1.19.1)
-    parser (2.7.0.0)
+    parser (2.7.0.1)
       ast (~> 2.4.0)
     pry (0.12.2)
       coderay (~> 1.1.0)

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -116,6 +116,7 @@ const createSubscription = controller => {
       {
         received: data => {
           if (!data.cableReady) return
+          if (!data.operations.morph || !data.operations.morph.length) return
           const urls = [
             ...new Set(data.operations.morph.map(m => m.stimulusReflex.url))
           ]
@@ -276,11 +277,7 @@ const getReflexRoots = element => {
       const selectors = reflexRoot.split(',').filter(s => s.trim().length)
       if (selectors.length === 0) {
         console.error(
-          `No value found for ${
-            app.schema.reflexRootAttribute
-          }. Add an #id to the element or provide a value for ${
-            app.schema.reflexRootAttribute
-          }.`,
+          `No value found for ${app.schema.reflexRootAttribute}. Add an #id to the element or provide a value for ${app.schema.reflexRootAttribute}.`,
           element
         )
       }


### PR DESCRIPTION
# Enhancement

## Description

Add another defensive check around morph operations in the received handler.

This will allow the StimulusReflex ActionCable subscription to also be used for
other unrelated CableReady DOM operations.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing