### PR TITLE
added current_user delegate

### DIFF
--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -5,6 +5,7 @@ class StimulusReflex::Reflex
 
   delegate :connection, to: :channel
   delegate :session, to: :request
+  delegate :current_user, to: :connection
 
   def initialize(channel, url: nil, element: nil, selectors: [])
     @channel = channel


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Enhancement

## Description

This allows developers to use the omnipresent `current_user` accessor inside of a Reflex class. It is assumed that they will assign `self.current_user` in their `connection.rb`.

This will be added to the documentation if accepted.

## Why should this be added

Developers reasonably expect `current_user` to be available anywhere in their application. We should do everything we can to provide an API that doesn't defy the principle of least surprise.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
