### PR TITLE
Add support for implicit global permanents

### DIFF
--- a/javascript/schema.js
+++ b/javascript/schema.js
@@ -1,6 +1,7 @@
 export const defaultSchema = {
   reflexAttribute: 'data-reflex',
-  reflexPermanentAttribute: 'data-reflex-permanent',
   reflexRootAttribute: 'data-reflex-root',
+  reflexPermanentAttribute: 'data-reflex-permanent',
+  reflexPermanentSelectors: ['input[type="hidden"][name="authenticity_token"]'],
   roomAttribute: 'data-room'
 }

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -22,7 +22,7 @@ let app
 
 // Initializes implicit data-reflex-permanent for text inputs.
 //
-const initializeImplicitReflexPermanent = event => {
+const initializeTextInputReflexPermanent = event => {
   const element = event.target
   if (!isTextInput(element)) return
   element.reflexPermanent = element.hasAttribute(
@@ -33,12 +33,29 @@ const initializeImplicitReflexPermanent = event => {
 
 // Resets implicit data-reflex-permanent for text inputs.
 //
-const resetImplicitReflexPermanent = event => {
+const resetTextInputReflexPermanent = event => {
   const element = event.target
   if (!isTextInput(element)) return
   if (element.reflexPermanent !== undefined && !element.reflexPermanent) {
     element.removeAttribute(app.schema.reflexPermanentAttribute)
   }
+}
+
+// Initializes implicit data-reflex-permanents.
+//
+const initializeImplicitReflexPermanents = event => {
+  initializeTextInputReflexPermanent(event)
+  app.schema.reflexPermanentSelectors.forEach(selector => {
+    document.querySelectorAll(selector).forEach(element => {
+      element.setAttribute(app.schema.reflexPermanentAttribute, '')
+    })
+  })
+}
+
+// Resets implicit data-reflex-permanents.
+//
+const resetImplicitReflexPermanents = event => {
+  resetTextInputReflexPermanent(event)
 }
 
 // Invokes a lifecycle method on a StimulusReflex controller.
@@ -336,8 +353,8 @@ if (!document.stimulusReflexInitialized) {
     invokeLifecycleMethod('error', target, element)
     invokeLifecycleMethod('after', target, element)
   })
-  document.addEventListener('focusin', initializeImplicitReflexPermanent)
-  document.addEventListener('focusout', resetImplicitReflexPermanent)
+  document.addEventListener('focusin', initializeImplicitReflexPermanents, true)
+  document.addEventListener('focusout', resetImplicitReflexPermanents, true)
 }
 
 export default { initialize, register }


### PR DESCRIPTION
# Enhancement

## Why should this be added

There are scenarios where users may need to ensure certain elements are always treated as a permanent. This is especially helpful for times you don't have explicit control over rendering said elements.

```js
// app/javascript/controllers.js
// ...
application.schema.reflexPermanentSelectors = ['#will-never-be-updated-by-stimulus-reflex']
StimulusReflex.initialize(application)
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing