### PR TITLE
authentication.md: Suggest storing only the session ID string

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -18,7 +18,7 @@ class ApplicationController < ActionController::Base
   private
 
   def set_action_cable_identifier
-    cookies.encrypted[:session_id] = session.id
+    cookies.encrypted[:session_id] = session.id.to_s
   end
 end	end
 ```


### PR DESCRIPTION
At least in Rails 6, `session.id` is an instance of `Rack::Session::SessionId`.

Without the `to_s`, `cookies.encrypted[:session_id]` will end up storing a hash like `{"public_id"=>"abc123"}`, which still seems to work, but seems unnecessary.