### PR TITLE
tweak prettier-standard and add actions caching

### DIFF
--- a/.github/workflows/prettier-standard.yml
+++ b/.github/workflows/prettier-standard.yml
@@ -18,6 +18,16 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: '12.x'
+    - name: Get yarn cache directory path
+      id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(yarn cache dir)"
+    - uses: actions/cache@v1
+      id: yarn-cache
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
     - run: yarn
       working-directory: javascript/
     - run: yarn run prettier-standard:check

--- a/.github/workflows/prettier-standard.yml
+++ b/.github/workflows/prettier-standard.yml
@@ -20,5 +20,5 @@ jobs:
         node-version: '12.x'
     - run: yarn
       working-directory: javascript/
-    - run: yarn run prettier-standard-check
+    - run: yarn run prettier-standard:check
       working-directory: javascript/

--- a/.github/workflows/prettier-standard.yml
+++ b/.github/workflows/prettier-standard.yml
@@ -28,7 +28,9 @@ jobs:
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
         restore-keys: |
           ${{ runner.os }}-yarn-
-    - run: yarn
+    - name: Yarn install
+      run: yarn
       working-directory: javascript/
-    - run: yarn run prettier-standard:check
+    - name: Run prettier-standard check
+      run: yarn run prettier-standard:check
       working-directory: javascript/

--- a/.github/workflows/standardrb.yml
+++ b/.github/workflows/standardrb.yml
@@ -18,9 +18,16 @@ jobs:
       uses: actions/setup-ruby@v1
       with:
         ruby-version: 2.6.x
+    - uses: actions/cache@v1
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gems-
     - name: Bundle
       run: |
         gem install bundler
+        bundle config path vendor/bundle
         bundle install --jobs 4 --retry 3
     - name: Run StandardRB
       run: bundle exec standardrb --format progress

--- a/.github/workflows/standardrb.yml
+++ b/.github/workflows/standardrb.yml
@@ -24,7 +24,7 @@ jobs:
         key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: |
           ${{ runner.os }}-gems-
-    - name: Bundle
+    - name: Bundle install
       run: |
         gem install bundler
         bundle config path vendor/bundle

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
         key: ${{ runner.os }}-${{ matrix.node }}-yarn-${{ hashFiles('**/yarn.lock') }}
         restore-keys: |
           ${{ runner.os }}-${{ matrix.node }}-yarn-
-    - name: Yarn
+    - name: Yarn install
       run: yarn
       working-directory: javascript/
     - name: Run JavaScript Tests
@@ -53,7 +53,7 @@ jobs:
         key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: |
           ${{ runner.os }}-gems-
-    - name: Bundle
+    - name: Bundle install
       run: |
         gem install bundler
         bundle config path vendor/bundle

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,16 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node }}
+    - name: Get yarn cache directory path
+      id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(yarn cache dir)"
+    - uses: actions/cache@v1
+      id: yarn-cache
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-${{ matrix.node }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.node }}-yarn-
     - name: Yarn
       run: yarn
       working-directory: javascript/
@@ -37,9 +47,16 @@ jobs:
       uses: actions/setup-ruby@v1
       with:
         ruby-version: 2.6.x
+    - uses: actions/cache@v1
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gems-
     - name: Bundle
       run: |
         gem install bundler
+        bundle config path vendor/bundle
         bundle install --jobs 4 --retry 3
     - name: Run ruby tests
       run: bundle exec rake test_ruby

--- a/bin/standardize
+++ b/bin/standardize
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 bundle exec standardrb --fix
-cd ./javascript && yarn run prettier-standard --lint javascript/*.js test/*.js
+cd ./javascript && yarn run prettier-standard:format

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -10,7 +10,8 @@
   },
   "scripts": {
     "test": "yarn run mocha --require @babel/register",
-    "prettier-standard-check": "yarn run prettier-standard --check ./**/*.js",
+    "prettier-standard:check": "yarn run prettier-standard --check ./**/*.js",
+    "prettier-standard:format": "yarn run prettier-standard ./**/*.js",
     "postinstall": "node scripts/post_install.js"
   },
   "dependencies": {

--- a/javascript/scripts/post_install.js
+++ b/javascript/scripts/post_install.js
@@ -1,5 +1,5 @@
 console.log(
-  "Friendly reminder: When updating the stimulus_reflex gem,\n" +
+  'Friendly reminder: When updating the stimulus_reflex gem,\n' +
     "don't forget to update your Ruby gem as well.\n\n" +
-    "See https://rubygems.org/gems/stimulus_reflex"
-);
+    'See https://rubygems.org/gems/stimulus_reflex'
+)

--- a/javascript/yarn.lock
+++ b/javascript/yarn.lock
@@ -3215,7 +3215,7 @@ parse-json@^4.0.0:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
 
-"parse-srcset@github:ikatyang/parse-srcset#54eb9c1cb21db5c62b4d0e275d7249516df6f0ee":
+parse-srcset@ikatyang/parse-srcset#54eb9c1cb21db5c62b4d0e275d7249516df6f0ee:
   version "1.0.2"
   resolved "https://codeload.github.com/ikatyang/parse-srcset/tar.gz/54eb9c1cb21db5c62b4d0e275d7249516df6f0ee"
 


### PR DESCRIPTION
# Enhancement

## Description

Small tweak to prettier-standard script and update standardize binstub so it works correctly.

Also adds caching for GitHub Actions.

## Why should this be added

This was not correctly catching and fixing a failing lint.

Caching will improve actions speed.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
