### PR TITLE
update install script to set session store

### DIFF
--- a/lib/tasks/stimulus_reflex/install.rake
+++ b/lib/tasks/stimulus_reflex/install.rake
@@ -27,6 +27,15 @@ namespace :stimulus_reflex do
     lines << "StimulusReflex.initialize(application)\n" unless initialize_line
     File.open(filepath, "w") { |f| f.write lines.join }
 
+    filepath = Rails.root.join("config/environments/development.rb")
+    lines = File.open(filepath, "r") { |f| f.readlines }
+    unless lines.find { |line| line.include?("config.session_store") }
+      lines.insert 3, "  config.session_store :cache_store\n\n"
+      File.open(filepath, "w") { |f| f.write lines.join }
+    end
+
     system "bundle exec rails generate stimulus_reflex example"
+    
+    system "rails dev:cache" unless Rails.root.join('tmp', 'caching-dev.txt').exist?
   end
 end

--- a/lib/tasks/stimulus_reflex/install.rake
+++ b/lib/tasks/stimulus_reflex/install.rake
@@ -36,6 +36,6 @@ namespace :stimulus_reflex do
 
     system "bundle exec rails generate stimulus_reflex example"
     
-    system "rails dev:cache" unless Rails.root.join('tmp', 'caching-dev.txt').exist?
+    system "rails dev:cache" unless Rails.root.join("tmp", "caching-dev.txt").exist?
   end
 end

--- a/lib/tasks/stimulus_reflex/install.rake
+++ b/lib/tasks/stimulus_reflex/install.rake
@@ -35,7 +35,6 @@ namespace :stimulus_reflex do
     end
 
     system "bundle exec rails generate stimulus_reflex example"
-    
     system "rails dev:cache" unless Rails.root.join("tmp", "caching-dev.txt").exist?
   end
 end


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

enhancement

## Description

SR no longer supports cookie session storage. For easy onboarding, this PR updates the install script to set the development environment to use the cache store as session backend. It also enables development mode caching if it is not yet enabled.

Fixes # (issue)

## Why should this be added

Minimize noob friction.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
