### PR TITLE
Allow #stimulate to use promises

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -37,7 +37,8 @@
     "@rails/actioncable": ">= 6.0",
     "cable_ready": ">= 4.1",
     "inflected": ">= 2.0",
-    "stimulus": ">= 1.1"
+    "stimulus": ">= 1.1",
+    "uuid": ">= 7.0.3"
   },
   "devDependencies": {
     "@babel/core": "^7.6.2",

--- a/javascript/yarn.lock
+++ b/javascript/yarn.lock
@@ -4367,6 +4367,11 @@ util@^0.12.0:
     is-generator-function "^1.0.7"
     safe-buffer "^5.1.2"
 
+"uuid@>= 7.0.3":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
+  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
+
 uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"


### PR DESCRIPTION
# Feature

## Description

The basic idea here is that we keep a table of promises indexed by
randomly generated UUIDs. The UUIDs are sent to the server on each
reflex call and are returned with responses, and thus can be used to
look up the promise we kept in our table, which we then resolve or
reject. This allows us to do stuff like

```javascript
this.stimulate('MyReflex#action')
  .then(() => this.doSomething())
  .catch(() => this.handleError())
```

## Why should this be added

Primar benefits:

* Using promises gives you the option to keep callback code near the location of `#stimulate` calls, as well as implement per-call behaviour as opposed to generalized callback methods.

* You can take advantage of the full `Promise` API, including functions like `Promise.all`, `Promise.allSettled`, and `Promise.race`, allowing for simple reflex orchestration when you are making multiple calls to reflexes and need to ensure behaviour based on their overall executions.

* You can use `await/async` syntactic sugar to further simplify some code patterns.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
