### PR TITLE
Create dynamic changelog

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,38 @@
+name: Changelog
+
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 4
+    if: "!contains(github.event.head_commit.message, '[nodoc]')"
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Ruby 2.6
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.6.x
+    - uses: actions/cache@v1.1.2
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gem-
+    - name: Create local changes
+      run: |
+        gem install bundler
+        bundle config path vendor/bundle
+        bundle install --jobs 4 --retry 3
+        bundle exec rake generate_changelog
+    - name: Commit files
+      run: |
+        git config --local user.email "actions@github.com"
+        git config --local user.name "GitHub Action"
+        git commit -m "[nodoc] update changelog" -a
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/standardrb.yml
+++ b/.github/workflows/standardrb.yml
@@ -1,33 +1,38 @@
-name: StandardRB
+name: Changelog
 
 on:
-  pull_request:
-    branches:
-      - '*'
   push:
     branches:
       - master
-
 jobs:
-  standard:
-    name: StandardRB Check Action
+  build:
     runs-on: ubuntu-latest
+    timeout-minutes: 4
+    if: "!contains(github.event.head_commit.message, '[nodoc]')"
     steps:
     - uses: actions/checkout@master
     - name: Set up Ruby 2.6
       uses: actions/setup-ruby@v1
       with:
         ruby-version: 2.6.x
-    - uses: actions/cache@v1
+    - uses: actions/cache@v1.1.2
       with:
         path: vendor/bundle
-        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: |
-          ${{ runner.os }}-gems-
-    - name: Bundle install
+          ${{ runner.os }}-gem-
+    - name: Create local changes
       run: |
         gem install bundler
         bundle config path vendor/bundle
         bundle install --jobs 4 --retry 3
-    - name: Run StandardRB
-      run: bundle exec standardrb --format progress
+        bundle exec rake generate_changelog
+    - name: Commit files
+      run: |
+        git config --local user.email "actions@github.com"
+        git config --local user.name "GitHub Action"
+        git commit -m "[nodoc] update changelog" -a
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/standardrb.yml
+++ b/.github/workflows/standardrb.yml
@@ -1,38 +1,33 @@
-name: Changelog
+name: StandardRB
 
 on:
+  pull_request:
+    branches:
+      - '*'
   push:
     branches:
       - master
+
 jobs:
-  build:
+  standard:
+    name: StandardRB Check Action
     runs-on: ubuntu-latest
-    timeout-minutes: 4
-    if: "!contains(github.event.head_commit.message, '[nodoc]')"
     steps:
     - uses: actions/checkout@master
     - name: Set up Ruby 2.6
       uses: actions/setup-ruby@v1
       with:
         ruby-version: 2.6.x
-    - uses: actions/cache@v1.1.2
+    - uses: actions/cache@v1
       with:
         path: vendor/bundle
-        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: |
-          ${{ runner.os }}-gem-
-    - name: Create local changes
+          ${{ runner.os }}-gems-
+    - name: Bundle install
       run: |
         gem install bundler
         bundle config path vendor/bundle
         bundle install --jobs 4 --retry 3
-        bundle exec rake generate_changelog
-    - name: Commit files
-      run: |
-        git config --local user.email "actions@github.com"
-        git config --local user.name "GitHub Action"
-        git commit -m "[nodoc] update changelog" -a
-    - name: Push changes
-      uses: ad-m/github-push-action@master
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Run StandardRB
+      run: bundle exec standardrb --format progress

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,383 @@
+# Changelog
+
+## [Unreleased](https://github.com/hopsoft/stimulus_reflex/tree/HEAD)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v3.0.0...HEAD)
+
+**Implemented enhancements:**
+
+- add funding file [\#141](https://github.com/hopsoft/stimulus_reflex/pull/141) ([andrewmcodes](https://github.com/andrewmcodes))
+
+## [v3.0.0](https://github.com/hopsoft/stimulus_reflex/tree/v3.0.0) (2020-04-06)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v2.2.3...v3.0.0)
+
+**Breaking changes:**
+
+- Update ActionCable JS dep to @rails/actioncable [\#135](https://github.com/hopsoft/stimulus_reflex/pull/135) ([hopsoft](https://github.com/hopsoft))
+
+**Implemented enhancements:**
+
+- update install script to set session store [\#134](https://github.com/hopsoft/stimulus_reflex/pull/134) ([leastbad](https://github.com/leastbad))
+- update package.json and readme [\#133](https://github.com/hopsoft/stimulus_reflex/pull/133) ([andrewmcodes](https://github.com/andrewmcodes))
+
+**Closed issues:**
+
+- \[WIP\] AnyCable and Stimulus Reflex [\#46](https://github.com/hopsoft/stimulus_reflex/issues/46)
+
+## [v2.2.3](https://github.com/hopsoft/stimulus_reflex/tree/v2.2.3) (2020-03-27)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v2.2.2...v2.2.3)
+
+**Implemented enhancements:**
+
+- Reload session prior to each reflex accessing it [\#131](https://github.com/hopsoft/stimulus_reflex/pull/131) ([hopsoft](https://github.com/hopsoft))
+- tweak prettier-standard and add actions caching [\#125](https://github.com/hopsoft/stimulus_reflex/pull/125) ([andrewmcodes](https://github.com/andrewmcodes))
+
+**Dependencies:**
+
+- Bump actionview from 6.0.2.1 to 6.0.2.2 [\#128](https://github.com/hopsoft/stimulus_reflex/pull/128) ([dependabot[bot]](https://github.com/apps/dependabot))
+
+**Closed issues:**
+
+- Cannot read property 'stimulusReflexController' of null [\#127](https://github.com/hopsoft/stimulus_reflex/issues/127)
+
+## [v2.2.2](https://github.com/hopsoft/stimulus_reflex/tree/v2.2.2) (2020-03-04)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v2.2.1...v2.2.2)
+
+**Implemented enhancements:**
+
+- Commit session after rerendering page [\#124](https://github.com/hopsoft/stimulus_reflex/pull/124) ([hopsoft](https://github.com/hopsoft))
+- Propose post install message [\#122](https://github.com/hopsoft/stimulus_reflex/pull/122) ([julianrubisch](https://github.com/julianrubisch))
+
+## [v2.2.1](https://github.com/hopsoft/stimulus_reflex/tree/v2.2.1) (2020-02-28)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v2.2.0...v2.2.1)
+
+**Fixed bugs:**
+
+- Cleanup and fixes around lifecycle dispatch [\#121](https://github.com/hopsoft/stimulus_reflex/pull/121) ([hopsoft](https://github.com/hopsoft))
+
+## [v2.2.0](https://github.com/hopsoft/stimulus_reflex/tree/v2.2.0) (2020-02-28)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v2.1.9...v2.2.0)
+
+**Implemented enhancements:**
+
+- Explicit and implicit registering of the ActionCable consumer [\#116](https://github.com/hopsoft/stimulus_reflex/pull/116) ([hopsoft](https://github.com/hopsoft))
+
+## [v2.1.9](https://github.com/hopsoft/stimulus_reflex/tree/v2.1.9) (2020-02-20)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v2.1.8...v2.1.9)
+
+**Implemented enhancements:**
+
+- Add lifecycle events [\#114](https://github.com/hopsoft/stimulus_reflex/issues/114)
+- Setup DOM event based lifecycle [\#115](https://github.com/hopsoft/stimulus_reflex/pull/115) ([hopsoft](https://github.com/hopsoft))
+
+## [v2.1.8](https://github.com/hopsoft/stimulus_reflex/tree/v2.1.8) (2020-01-27)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v2.1.7...v2.1.8)
+
+**Implemented enhancements:**
+
+- More defense in the received handler [\#107](https://github.com/hopsoft/stimulus_reflex/pull/107) ([hopsoft](https://github.com/hopsoft))
+
+**Fixed bugs:**
+
+- Fix bug related to trailing slash in URL path [\#111](https://github.com/hopsoft/stimulus_reflex/pull/111) ([hopsoft](https://github.com/hopsoft))
+
+## [v2.1.7](https://github.com/hopsoft/stimulus_reflex/tree/v2.1.7) (2019-12-28)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v2.1.6...v2.1.7)
+
+**Implemented enhancements:**
+
+- Support devise authenticated routes [\#105](https://github.com/hopsoft/stimulus_reflex/pull/105) ([hopsoft](https://github.com/hopsoft))
+
+**Closed issues:**
+
+- SR cannot re-render authenticated devise routes [\#104](https://github.com/hopsoft/stimulus_reflex/issues/104)
+- Docs formatting broken in Persistence section [\#93](https://github.com/hopsoft/stimulus_reflex/issues/93)
+
+## [v2.1.6](https://github.com/hopsoft/stimulus_reflex/tree/v2.1.6) (2019-12-20)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v2.1.5...v2.1.6)
+
+**Implemented enhancements:**
+
+- StimulusReflex::Channel - Error messages include stack trace info [\#100](https://github.com/hopsoft/stimulus_reflex/pull/100) ([szTheory](https://github.com/szTheory))
+
+**Closed issues:**
+
+- Demo appears to be broken [\#101](https://github.com/hopsoft/stimulus_reflex/issues/101)
+
+## [v2.1.5](https://github.com/hopsoft/stimulus_reflex/tree/v2.1.5) (2019-11-04)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v2.1.4...v2.1.5)
+
+**Implemented enhancements:**
+
+- Custom Stimulus schema breaks Reflex [\#91](https://github.com/hopsoft/stimulus_reflex/issues/91)
+- Add schema support [\#94](https://github.com/hopsoft/stimulus_reflex/pull/94) ([hopsoft](https://github.com/hopsoft))
+- inherit stimulus schema [\#92](https://github.com/hopsoft/stimulus_reflex/pull/92) ([nickyvanurk](https://github.com/nickyvanurk))
+- Single source of truth [\#76](https://github.com/hopsoft/stimulus_reflex/pull/76) ([leastbad](https://github.com/leastbad))
+
+**Fixed bugs:**
+
+- Use application.js as fallback file path [\#82](https://github.com/hopsoft/stimulus_reflex/pull/82) ([julianrubisch](https://github.com/julianrubisch))
+
+**Closed issues:**
+
+- Slack Community [\#90](https://github.com/hopsoft/stimulus_reflex/issues/90)
+- Installer fails on fresh Rails 5.2.3 app w/ webpacker 3.6 [\#81](https://github.com/hopsoft/stimulus_reflex/issues/81)
+- Correct List Order in setup.md under Rooms Section [\#78](https://github.com/hopsoft/stimulus_reflex/issues/78)
+- Scoped onClick event [\#73](https://github.com/hopsoft/stimulus_reflex/issues/73)
+
+## [v2.1.4](https://github.com/hopsoft/stimulus_reflex/tree/v2.1.4) (2019-10-19)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v2.1.3...v2.1.4)
+
+**Implemented enhancements:**
+
+- Add CodeFund sponsorship [\#75](https://github.com/hopsoft/stimulus_reflex/pull/75) ([coderberry](https://github.com/coderberry))
+
+**Fixed bugs:**
+
+- Don't assume that connection identifiers are model instances [\#77](https://github.com/hopsoft/stimulus_reflex/pull/77) ([hopsoft](https://github.com/hopsoft))
+
+## [v2.1.3](https://github.com/hopsoft/stimulus_reflex/tree/v2.1.3) (2019-10-16)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v2.1.2...v2.1.3)
+
+**Implemented enhancements:**
+
+- Create Rails generators [\#3](https://github.com/hopsoft/stimulus_reflex/issues/3)
+- Update installer [\#71](https://github.com/hopsoft/stimulus_reflex/pull/71) ([hopsoft](https://github.com/hopsoft))
+- Tweak generators [\#69](https://github.com/hopsoft/stimulus_reflex/pull/69) ([hopsoft](https://github.com/hopsoft))
+- add generators [\#67](https://github.com/hopsoft/stimulus_reflex/pull/67) ([andrewmcodes](https://github.com/andrewmcodes))
+
+**Fixed bugs:**
+
+- too many afterReflex/reflexSuccess callbacks [\#68](https://github.com/hopsoft/stimulus_reflex/issues/68)
+- Prevent redundant `after` lifecycle callbacks [\#70](https://github.com/hopsoft/stimulus_reflex/pull/70) ([hopsoft](https://github.com/hopsoft))
+
+## [v2.1.2](https://github.com/hopsoft/stimulus_reflex/tree/v2.1.2) (2019-10-09)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v2.1.1...v2.1.2)
+
+## [v2.1.1](https://github.com/hopsoft/stimulus_reflex/tree/v2.1.1) (2019-10-08)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v2.1.0...v2.1.1)
+
+**Fixed bugs:**
+
+- Fix issue in reflex root discovery [\#66](https://github.com/hopsoft/stimulus_reflex/pull/66) ([hopsoft](https://github.com/hopsoft))
+
+## [v2.1.0](https://github.com/hopsoft/stimulus_reflex/tree/v2.1.0) (2019-10-07)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v2.0.2...v2.1.0)
+
+**Implemented enhancements:**
+
+- Move ActionCable room configuration to controller registration [\#51](https://github.com/hopsoft/stimulus_reflex/issues/51)
+- Client side call-backs? [\#34](https://github.com/hopsoft/stimulus_reflex/issues/34)
+- Scoped register\(\)? [\#26](https://github.com/hopsoft/stimulus_reflex/issues/26)
+- Add guard to verify same URL prior to morph [\#63](https://github.com/hopsoft/stimulus_reflex/pull/63) ([hopsoft](https://github.com/hopsoft))
+- Add reflex name to the lifecycle args [\#62](https://github.com/hopsoft/stimulus_reflex/pull/62) ([hopsoft](https://github.com/hopsoft))
+- Refactor some helper methods out of main file [\#61](https://github.com/hopsoft/stimulus_reflex/pull/61) ([hopsoft](https://github.com/hopsoft))
+- Documentation update [\#58](https://github.com/hopsoft/stimulus_reflex/pull/58) ([leastbad](https://github.com/leastbad))
+- \# Support for data-reflex-permanent [\#57](https://github.com/hopsoft/stimulus_reflex/pull/57) ([hopsoft](https://github.com/hopsoft))
+- Stricter parsing of attributes [\#56](https://github.com/hopsoft/stimulus_reflex/pull/56) ([hopsoft](https://github.com/hopsoft))
+- \# Use inner\_html to avoid reliance on HTMLTemplateElement behavior [\#55](https://github.com/hopsoft/stimulus_reflex/pull/55) ([hopsoft](https://github.com/hopsoft))
+- Trim values before attribute assignment [\#54](https://github.com/hopsoft/stimulus_reflex/pull/54) ([hopsoft](https://github.com/hopsoft))
+- add test action [\#53](https://github.com/hopsoft/stimulus_reflex/pull/53) ([andrewmcodes](https://github.com/andrewmcodes))
+- Scoped Stimulus Reflex controllers [\#43](https://github.com/hopsoft/stimulus_reflex/pull/43) ([leastbad](https://github.com/leastbad))
+
+**Closed issues:**
+
+- Install StandardJS linter [\#40](https://github.com/hopsoft/stimulus_reflex/issues/40)
+
+## [v2.0.2](https://github.com/hopsoft/stimulus_reflex/tree/v2.0.2) (2019-09-30)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v2.0.1...v2.0.2)
+
+**Implemented enhancements:**
+
+- Add support to configure room via register option [\#52](https://github.com/hopsoft/stimulus_reflex/pull/52) ([hopsoft](https://github.com/hopsoft))
+- Move gitbook files to docs [\#49](https://github.com/hopsoft/stimulus_reflex/pull/49) ([hopsoft](https://github.com/hopsoft))
+
+**Closed issues:**
+
+- Formatting issues on README [\#48](https://github.com/hopsoft/stimulus_reflex/issues/48)
+
+## [v2.0.1](https://github.com/hopsoft/stimulus_reflex/tree/v2.0.1) (2019-09-28)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v2.0.0...v2.0.1)
+
+**Implemented enhancements:**
+
+- Provide before/after callbacks for calls delegated to server side Stimulus controllers [\#4](https://github.com/hopsoft/stimulus_reflex/issues/4)
+- Updated Minimal Javascript Example in README.md [\#47](https://github.com/hopsoft/stimulus_reflex/pull/47) ([kobaltz](https://github.com/kobaltz))
+- Setup StimulusReflex controller callbacks [\#45](https://github.com/hopsoft/stimulus_reflex/pull/45) ([hopsoft](https://github.com/hopsoft))
+- add .vscode directory to .gitignore [\#42](https://github.com/hopsoft/stimulus_reflex/pull/42) ([andrewmcodes](https://github.com/andrewmcodes))
+- Allow override of default controller [\#37](https://github.com/hopsoft/stimulus_reflex/pull/37) ([hopsoft](https://github.com/hopsoft))
+- update the name of the actions per feedback [\#36](https://github.com/hopsoft/stimulus_reflex/pull/36) ([andrewmcodes](https://github.com/andrewmcodes))
+- update github templates [\#35](https://github.com/hopsoft/stimulus_reflex/pull/35) ([andrewmcodes](https://github.com/andrewmcodes))
+- Tighten up security of remote invocation [\#32](https://github.com/hopsoft/stimulus_reflex/pull/32) ([hopsoft](https://github.com/hopsoft))
+
+**Fixed bugs:**
+
+- Reflex is a reflex [\#38](https://github.com/hopsoft/stimulus_reflex/pull/38) ([leastbad](https://github.com/leastbad))
+
+**Closed issues:**
+
+- Add GH templates [\#30](https://github.com/hopsoft/stimulus_reflex/issues/30)
+
+## [v2.0.0](https://github.com/hopsoft/stimulus_reflex/tree/v2.0.0) (2019-09-11)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v1.1.1...v2.0.0)
+
+**Implemented enhancements:**
+
+- update github action triggers [\#29](https://github.com/hopsoft/stimulus_reflex/pull/29) ([andrewmcodes](https://github.com/andrewmcodes))
+- Add support for declarative stimulus/reflex behavior [\#28](https://github.com/hopsoft/stimulus_reflex/pull/28) ([hopsoft](https://github.com/hopsoft))
+
+**Fixed bugs:**
+
+- fix merge issue for GitHub actions [\#27](https://github.com/hopsoft/stimulus_reflex/pull/27) ([andrewmcodes](https://github.com/andrewmcodes))
+
+## [v1.1.1](https://github.com/hopsoft/stimulus_reflex/tree/v1.1.1) (2019-09-09)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v1.1.0...v1.1.1)
+
+## [v1.1.0](https://github.com/hopsoft/stimulus_reflex/tree/v1.1.0) (2019-09-09)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v1.0.2...v1.1.0)
+
+**Implemented enhancements:**
+
+- Implicitly send DOM attributes to reflex methods [\#21](https://github.com/hopsoft/stimulus_reflex/pull/21) ([hopsoft](https://github.com/hopsoft))
+- Add Ruby magic comment [\#18](https://github.com/hopsoft/stimulus_reflex/pull/18) ([dixpac](https://github.com/dixpac))
+- Add GitHub Actions for Linters [\#17](https://github.com/hopsoft/stimulus_reflex/pull/17) ([andrewmcodes](https://github.com/andrewmcodes))
+
+**Fixed bugs:**
+
+- Fix GitHub Actions [\#20](https://github.com/hopsoft/stimulus_reflex/pull/20) ([andrewmcodes](https://github.com/andrewmcodes))
+
+## [v1.0.2](https://github.com/hopsoft/stimulus_reflex/tree/v1.0.2) (2019-08-17)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v1.0.1...v1.0.2)
+
+**Implemented enhancements:**
+
+- Small performance enhancements [\#16](https://github.com/hopsoft/stimulus_reflex/pull/16) ([hopsoft](https://github.com/hopsoft))
+
+## [v1.0.1](https://github.com/hopsoft/stimulus_reflex/tree/v1.0.1) (2019-08-10)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v1.0.0...v1.0.1)
+
+**Implemented enhancements:**
+
+- Add support for rooms [\#11](https://github.com/hopsoft/stimulus_reflex/pull/11) ([hopsoft](https://github.com/hopsoft))
+
+**Closed issues:**
+
+- Trying to get this working in Rails 6 [\#8](https://github.com/hopsoft/stimulus_reflex/issues/8)
+
+## [v1.0.0](https://github.com/hopsoft/stimulus_reflex/tree/v1.0.0) (2019-08-09)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v0.3.3...v1.0.0)
+
+**Implemented enhancements:**
+
+- Ruby function splat args return arity of -1 [\#9](https://github.com/hopsoft/stimulus_reflex/pull/9) ([leastbad](https://github.com/leastbad))
+
+## [v0.3.3](https://github.com/hopsoft/stimulus_reflex/tree/v0.3.3) (2019-05-13)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v0.3.2...v0.3.3)
+
+## [v0.3.2](https://github.com/hopsoft/stimulus_reflex/tree/v0.3.2) (2019-03-25)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v0.3.1...v0.3.2)
+
+## [v0.3.1](https://github.com/hopsoft/stimulus_reflex/tree/v0.3.1) (2019-03-01)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v0.3.0...v0.3.1)
+
+## [v0.3.0](https://github.com/hopsoft/stimulus_reflex/tree/v0.3.0) (2019-02-20)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v0.2.0...v0.3.0)
+
+**Breaking changes:**
+
+- Update naming conventions [\#7](https://github.com/hopsoft/stimulus_reflex/pull/7) ([hopsoft](https://github.com/hopsoft))
+
+## [v0.2.0](https://github.com/hopsoft/stimulus_reflex/tree/v0.2.0) (2018-11-16)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v0.1.12...v0.2.0)
+
+**Implemented enhancements:**
+
+- Explicit opt-in for ActionCable connection [\#6](https://github.com/hopsoft/stimulus_reflex/pull/6) ([hopsoft](https://github.com/hopsoft))
+
+## [v0.1.12](https://github.com/hopsoft/stimulus_reflex/tree/v0.1.12) (2018-11-03)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v0.1.10...v0.1.12)
+
+## [v0.1.10](https://github.com/hopsoft/stimulus_reflex/tree/v0.1.10) (2018-10-26)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v0.1.9...v0.1.10)
+
+## [v0.1.9](https://github.com/hopsoft/stimulus_reflex/tree/v0.1.9) (2018-10-24)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v0.1.8...v0.1.9)
+
+**Closed issues:**
+
+- URL helpers generate the wrong paths when page is rendered [\#1](https://github.com/hopsoft/stimulus_reflex/issues/1)
+
+## [v0.1.8](https://github.com/hopsoft/stimulus_reflex/tree/v0.1.8) (2018-10-22)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v0.1.7...v0.1.8)
+
+**Fixed bugs:**
+
+- Update env so url helpers work [\#2](https://github.com/hopsoft/stimulus_reflex/pull/2) ([hopsoft](https://github.com/hopsoft))
+
+## [v0.1.7](https://github.com/hopsoft/stimulus_reflex/tree/v0.1.7) (2018-10-21)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v0.1.6...v0.1.7)
+
+## [v0.1.6](https://github.com/hopsoft/stimulus_reflex/tree/v0.1.6) (2018-10-21)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v0.1.5...v0.1.6)
+
+## [v0.1.5](https://github.com/hopsoft/stimulus_reflex/tree/v0.1.5) (2018-10-20)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v0.1.4...v0.1.5)
+
+## [v0.1.4](https://github.com/hopsoft/stimulus_reflex/tree/v0.1.4) (2018-10-20)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v0.1.3...v0.1.4)
+
+## [v0.1.3](https://github.com/hopsoft/stimulus_reflex/tree/v0.1.3) (2018-10-20)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v0.1.2...v0.1.3)
+
+## [v0.1.2](https://github.com/hopsoft/stimulus_reflex/tree/v0.1.2) (2018-10-20)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v0.1.1...v0.1.2)
+
+## [v0.1.1](https://github.com/hopsoft/stimulus_reflex/tree/v0.1.1) (2018-10-20)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v0.1.0...v0.1.1)
+
+## [v0.1.0](https://github.com/hopsoft/stimulus_reflex/tree/v0.1.0) (2018-10-14)
+
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/bbd0d068aa40abb7d9f13deb099645dae3d5b3ed...v0.1.0)
+
+
+
+\* *This Changelog was automatically generated by [github_changelog_generator](https://github.com/github-changelog-generator/github-changelog-generator)*

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,8 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.0)
     builder (3.2.4)
     cable_ready (4.1.0)
@@ -73,6 +75,18 @@ GEM
     concurrent-ruby (1.1.6)
     crass (1.0.6)
     erubi (1.9.0)
+    faraday (0.17.3)
+      multipart-post (>= 1.2, < 3)
+    faraday-http-cache (2.1.0)
+      faraday (~> 0.8)
+    github_changelog_generator (1.15.2)
+      activesupport
+      faraday-http-cache
+      multi_json
+      octokit (~> 4.6)
+      rainbow (>= 2.2.1)
+      rake (>= 10.0)
+      retriable (~> 3.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     i18n (1.8.2)
@@ -90,9 +104,14 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.0)
+    multi_json (1.14.1)
+    multipart-post (2.1.1)
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
+    octokit (4.18.0)
+      faraday (>= 0.9)
+      sawyer (~> 0.8.0, >= 0.5.3)
     parallel (1.19.1)
     parser (2.7.1.0)
       ast (~> 2.4.0)
@@ -101,6 +120,7 @@ GEM
       method_source (~> 0.9.0)
     pry-nav (0.3.0)
       pry (>= 0.9.10, < 0.13.0)
+    public_suffix (4.0.4)
     rack (2.2.2)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -132,6 +152,7 @@ GEM
       thor (>= 0.20.3, < 2.0)
     rainbow (3.0.0)
     rake (13.0.1)
+    retriable (3.1.2)
     rexml (3.2.4)
     rubocop (0.80.1)
       jaro_winkler (~> 1.5.1)
@@ -144,6 +165,9 @@ GEM
     rubocop-performance (1.5.2)
       rubocop (>= 0.71.0)
     ruby-progressbar (1.10.1)
+    sawyer (0.8.2)
+      addressable (>= 2.3.5)
+      faraday (> 0.8, < 2.0)
     sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -171,6 +195,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 2.0)
+  github_changelog_generator
   pry
   pry-nav
   rake

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@
 
 require "bundler/gem_tasks"
 require "rails/test_unit/runner"
+require "github_changelog_generator/task"
 
 task default: [:test]
 
@@ -12,4 +13,12 @@ end
 
 task :test_ruby do |task|
   Rails::TestUnit::Runner.run
+end
+
+GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+  config.add_sections = {dependencies: {prefix: "**Dependencies:**", labels: ["dependencies"]}}
+  config.exclude_labels = ["duplicate", "question", "invalid", "wontfix", "nodoc"]
+  config.user = "hopsoft"
+  config.project = "stimulus_reflex"
+  config.token = ENV["GITHUB_TOKEN"]
 end

--- a/stimulus_reflex.gemspec
+++ b/stimulus_reflex.gemspec
@@ -15,6 +15,14 @@ Gem::Specification.new do |gem|
     See https://www.npmjs.com/package/stimulus_reflex
   MESSAGE
 
+  gem.metadata = {
+    "bug_tracker_uri" => "https://github.com/hopsoft/stimulus_reflex/issues",
+    "changelog_uri" => "https://github.com/hopsoft/stimulus_reflex/CHANGELOG.md",
+    "documentation_uri" => "https://docs.stimulusreflex.com",
+    "homepage_uri" => gem.homepage,
+    "source_code_uri" => gem.homepage
+  }
+
   gem.files = Dir["lib/**/*", "bin/*", "[A-Z]*"]
   gem.test_files = Dir["test/**/*.rb"]
 

--- a/stimulus_reflex.gemspec
+++ b/stimulus_reflex.gemspec
@@ -24,8 +24,9 @@ Gem::Specification.new do |gem|
   gem.add_dependency "cable_ready", ">= 4.1"
 
   gem.add_development_dependency "bundler", "~> 2.0"
-  gem.add_development_dependency "rake"
-  gem.add_development_dependency "pry"
+  gem.add_development_dependency "github_changelog_generator"
   gem.add_development_dependency "pry-nav"
+  gem.add_development_dependency "pry"
+  gem.add_development_dependency "rake"
   gem.add_development_dependency "standardrb"
 end


### PR DESCRIPTION
# Enhancement

## Description

Adds a GitHub action to dynamicallly generate the changelog on pushes to master.

Also generates the changelog  to this point.

## Why should this be added

This will make it easier for users to upgrade the gem in their project.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
