### PR TITLE
Allow other CableReady operations to perform

### DIFF
--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -58,11 +58,12 @@ const createSubscription = controller => {
     actionCableConsumer.subscriptions.create(channel, {
       received: data => {
         if (!data.cableReady) return
-        if (!data.operations.morph || !data.operations.morph.length) return
-        const urls = [
-          ...new Set(data.operations.morph.map(m => m.stimulusReflex.url))
-        ]
-        if (urls.length !== 1 || urls[0] !== location.href) return
+        if (data.operations.morph && data.operations.morph.length) {
+          const urls = [
+            ...new Set(data.operations.morph.map(m => m.stimulusReflex.url))
+          ]
+          if (urls.length !== 1 || urls[0] !== location.href) return
+        }
         CableReady.perform(data.operations)
       }
     })


### PR DESCRIPTION
# Bug fix

## Description

We currently prevent all CableReady operations other than `morph`. This PR ensures that other operations are still executed which supports proper error handling of server side errors etc...

NOTE: This appears to be a duplicate of #140 and should also fix #139

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing