### PR TITLE
Attach element.tagName to extracted attributes

### DIFF
--- a/docs/reflexes.md
+++ b/docs/reflexes.md
@@ -47,7 +47,7 @@ StimulusReflex makes the following properties available to the developer in the 
 
 ### `element`
 
-The `element` property contains all of the Stimulus controller's [DOM element attributes](https://developer.mozilla.org/en-US/docs/Web/API/Element/attributes) as well as other properties like `checked` and `value`.
+The `element` property contains all of the Stimulus controller's [DOM element attributes](https://developer.mozilla.org/en-US/docs/Web/API/Element/attributes) as well as other properties like, `tagName`, `checked` and `value`.
 
 {% hint style="info" %}
 **Most values are strings.** The only exceptions are `checked` and `selected` which are booleans.
@@ -70,6 +70,7 @@ class ExampleReflex < StimulusReflex::Reflex
     element.dataset # => a Hash that represents the HTML element's dataset
 
     element[:id]                 # => "example"
+    element[:tag_name]           # => "CHECKBOX"
     element[:checked]            # => true
     element[:label]              # => "Example"
     element["data-reflex"]       # => "ExampleReflex#work"

--- a/javascript/attributes.js
+++ b/javascript/attributes.js
@@ -34,6 +34,7 @@ export const extractElementAttributes = element => {
   attrs.value = element.value
   attrs.checked = !!element.checked
   attrs.selected = !!element.selected
+  attrs.tag_name = element.tagName
   if (element.tagName.match(/select/i)) {
     if (element.multiple) {
       const checkedOptions = Array.prototype.slice.call(

--- a/javascript/test/attributes.extractElementAttributes.test.js
+++ b/javascript/test/attributes.extractElementAttributes.test.js
@@ -7,7 +7,12 @@ describe('extractElementAttributes', () => {
     const dom = new JSDOM('<a>Test</a>')
     const element = dom.window.document.querySelector('a')
     const actual = extractElementAttributes(element)
-    const expected = { value: undefined, checked: false, selected: false }
+    const expected = {
+      value: undefined,
+      checked: false,
+      selected: false,
+      tag_name: 'A'
+    }
     assert.deepStrictEqual(actual, expected)
   })
 
@@ -23,6 +28,7 @@ describe('extractElementAttributes', () => {
       'data-reflex': 'bar',
       'data-info': '12345',
       value: undefined,
+      tag_name: 'A',
       checked: false,
       selected: false
     }
@@ -36,6 +42,7 @@ describe('extractElementAttributes', () => {
     const expected = {
       id: 'example',
       value: 'StimulusReflex',
+      tag_name: 'TEXTAREA',
       checked: false,
       selected: false
     }
@@ -52,6 +59,7 @@ describe('extractElementAttributes', () => {
       type: 'text',
       id: 'example',
       value: 'StimulusReflex',
+      tag_name: 'INPUT',
       checked: false,
       selected: false
     }
@@ -66,6 +74,7 @@ describe('extractElementAttributes', () => {
       type: 'checkbox',
       id: 'example',
       value: 'on',
+      tag_name: 'INPUT',
       checked: false,
       selected: false
     }
@@ -80,6 +89,7 @@ describe('extractElementAttributes', () => {
       type: 'checkbox',
       id: 'example',
       value: 'on',
+      tag_name: 'INPUT',
       checked: true,
       selected: false
     }


### PR DESCRIPTION
# Enhancement

## Description

Attach the `element.tagName` to extracted attributes. This can be handy in some backend scenarios.

Fixes #137 

## Why should this be added

in some context it occured to me that it would be feasible not only to have checked, selected and value(s) attributes, but also to be able to discern between SELECT, OPTGROUP etc. etc.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] Checks (StandardRB & Prettier-Standard) are passing
