### PR TITLE
remove changelog rake task

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -23,14 +24,12 @@ jobs:
           ${{ runner.os }}-gem-
     - name: Create local changes
       run: |
-        gem install bundler
-        bundle config path vendor/bundle
-        bundle install --jobs 4 --retry 3
-        bundle exec rake generate_changelog
+        gem install github_changelog_generator
+        github_changelog_generator -u hopsoft -p stimulus_reflex --token ${{ secrets.GITHUB_TOKEN }} --exclude-labels duplicate,question,invalid,wontfix,nodoc
     - name: Commit files
       run: |
-        git config --local user.email "actions@github.com"
-        git config --local user.name "GitHub Action"
+        git config --local user.email "github-actions@example.com"
+        git config --local user.name "GitHub Actions"
         git commit -m "[nodoc] update changelog" -a
     - name: Push changes
       uses: ad-m/github-push-action@master

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,8 +65,6 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2)
-    addressable (2.7.0)
-      public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.0)
     builder (3.2.4)
     cable_ready (4.1.0)
@@ -75,18 +73,6 @@ GEM
     concurrent-ruby (1.1.6)
     crass (1.0.6)
     erubi (1.9.0)
-    faraday (1.0.1)
-      multipart-post (>= 1.2, < 3)
-    faraday-http-cache (2.2.0)
-      faraday (>= 0.8)
-    github_changelog_generator (1.15.2)
-      activesupport
-      faraday-http-cache
-      multi_json
-      octokit (~> 4.6)
-      rainbow (>= 2.2.1)
-      rake (>= 10.0)
-      retriable (~> 3.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     i18n (1.8.2)
@@ -104,14 +90,9 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.0)
-    multi_json (1.14.1)
-    multipart-post (2.1.1)
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
-    octokit (4.18.0)
-      faraday (>= 0.9)
-      sawyer (~> 0.8.0, >= 0.5.3)
     parallel (1.19.1)
     parser (2.7.1.1)
       ast (~> 2.4.0)
@@ -120,7 +101,6 @@ GEM
       method_source (~> 0.9.0)
     pry-nav (0.3.0)
       pry (>= 0.9.10, < 0.13.0)
-    public_suffix (4.0.4)
     rack (2.2.2)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -152,7 +132,6 @@ GEM
       thor (>= 0.20.3, < 2.0)
     rainbow (3.0.0)
     rake (13.0.1)
-    retriable (3.1.2)
     rexml (3.2.4)
     rubocop (0.80.1)
       jaro_winkler (~> 1.5.1)
@@ -165,9 +144,6 @@ GEM
     rubocop-performance (1.5.2)
       rubocop (>= 0.71.0)
     ruby-progressbar (1.10.1)
-    sawyer (0.8.2)
-      addressable (>= 2.3.5)
-      faraday (> 0.8, < 2.0)
     sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -195,7 +171,6 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 2.0)
-  github_changelog_generator
   pry
   pry-nav
   rake

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,6 @@
 
 require "bundler/gem_tasks"
 require "rails/test_unit/runner"
-require "github_changelog_generator/task"
 
 task default: [:test]
 
@@ -13,12 +12,4 @@ end
 
 task :test_ruby do |task|
   Rails::TestUnit::Runner.run
-end
-
-GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-  config.add_sections = {dependencies: {prefix: "**Dependencies:**", labels: ["dependencies"]}}
-  config.exclude_labels = ["duplicate", "question", "invalid", "wontfix", "nodoc"]
-  config.user = "hopsoft"
-  config.project = "stimulus_reflex"
-  config.token = ENV["GITHUB_TOKEN"]
 end

--- a/stimulus_reflex.gemspec
+++ b/stimulus_reflex.gemspec
@@ -32,7 +32,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency "cable_ready", ">= 4.1"
 
   gem.add_development_dependency "bundler", "~> 2.0"
-  gem.add_development_dependency "github_changelog_generator"
   gem.add_development_dependency "pry-nav"
   gem.add_development_dependency "pry"
   gem.add_development_dependency "rake"


### PR DESCRIPTION
# Bug fix

## Description

Fix changelog action.

Remove rake task and github_changelog_generator development dependency and the changelog command into the action.

## Why should this be added

The changelog action does not currently work.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
