### PR TITLE
replace implicit data-reflex-permanent with skipMorph flag

### DIFF
--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -23,22 +23,6 @@ let actionCableConsumer
 
 const promises = {}
 
-// Initializes implicit data-reflex-protect-value for text inputs.
-//
-const initializeImplicitReflexProtectValue = event => {
-  const element = event.target
-  if (!isTextInput(element)) return
-  element.skipMorph = true
-}
-
-// Resets implicit data-reflex-protect-value for text inputs.
-//
-const resetImplicitReflexProtectValue = event => {
-  const element = event.target
-  if (!isTextInput(element)) return
-  element.skipMorph = false
-}
-
 // Subscribes a StimulusReflex controller to an ActionCable channel.
 //
 // controller - the StimulusReflex controller to subscribe
@@ -314,8 +298,16 @@ if (!document.stimulusReflexInitialized) {
 
     dispatchLifecycleEvent('error', element)
   })
-  document.addEventListener('focusin', initializeImplicitReflexProtectValue)
-  document.addEventListener('focusout', resetImplicitReflexProtectValue)
+  document.addEventListener('focusin', event => {
+    const element = event.target
+    if (!isTextInput(element)) return
+    element.skipMorph = true
+  })
+  document.addEventListener('focusout', event => {
+    const element = event.target
+    if (!isTextInput(element)) return
+    element.skipMorph = false
+  })
 }
 
 export default { initialize, register }

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -23,25 +23,20 @@ let actionCableConsumer
 
 const promises = {}
 
-// Initializes implicit data-reflex-permanent for text inputs.
+// Initializes implicit data-reflex-protect-value for text inputs.
 //
-const initializeImplicitReflexPermanent = event => {
+const initializeImplicitReflexProtectValue = event => {
   const element = event.target
   if (!isTextInput(element)) return
-  element.reflexPermanent = element.hasAttribute(
-    stimulusApplication.schema.reflexPermanentAttribute
-  )
-  element.setAttribute(stimulusApplication.schema.reflexPermanentAttribute, '')
+  element.skipMorph = true
 }
 
-// Resets implicit data-reflex-permanent for text inputs.
+// Resets implicit data-reflex-protect-value for text inputs.
 //
-const resetImplicitReflexPermanent = event => {
+const resetImplicitReflexProtectValue = event => {
   const element = event.target
   if (!isTextInput(element)) return
-  if (element.reflexPermanent !== undefined && !element.reflexPermanent) {
-    element.removeAttribute(stimulusApplication.schema.reflexPermanentAttribute)
-  }
+  element.skipMorph = false
 }
 
 // Subscribes a StimulusReflex controller to an ActionCable channel.
@@ -319,8 +314,8 @@ if (!document.stimulusReflexInitialized) {
 
     dispatchLifecycleEvent('error', element)
   })
-  document.addEventListener('focusin', initializeImplicitReflexPermanent)
-  document.addEventListener('focusout', resetImplicitReflexPermanent)
+  document.addEventListener('focusin', initializeImplicitReflexProtectValue)
+  document.addEventListener('focusout', resetImplicitReflexProtectValue)
 }
 
 export default { initialize, register }


### PR DESCRIPTION
# Enhancement

## Morph current focused input without mutating text value

**Important note: this PR is dependent on the acceptance of [this PR on the morphdom project](https://github.com/patrick-steele-idem/morphdom/pull/188) as there is no skipMorph checking in today's morphdom.**

morphdom is a miracle of software engineering, but it takes an all-or-nothing approach when it comes to updating an element; there's no facility to tweak or whitelist/blacklist what properties/attributes get updated during an operation.

StimulusReflex and LiveView both take pains to make sure that the client is a single source of truth; the server should not accidentally update the value of a text input that you're currently typing into. We created the `data-reflex-permanent` attribute to protect hierarchies of elements from all morph updates, but what if you just want to protect the value of the element you're typing into? When something is made permanent, you can no longer do any updates to it, even if they are desirable. Live feedback via CSS updates beome impossible, for example. You cannot dynamically disable or reenable an element.

Instead of setting the currently focused input to permanent, let's instead set a boolean value called `skipMorph` on the element which can be checked by morphdom. If `skipMorph` is true, allow morph updates unless they attempt to change the text value.

## Why should this be added

![success](https://user-images.githubusercontent.com/38150464/79699299-b6945d00-825c-11ea-9081-082e6970e83b.gif)

With this PR, developers will be able to change the CSS and other non-text attributes of the currently focused input element with a morph without overwriting the current text value. The client remains the single source of truth.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
