### PR TITLE
Remove unneeded registerConsumer logic

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,7 +67,7 @@ GEM
       zeitwerk (~> 2.2)
     ast (2.4.0)
     builder (3.2.4)
-    cable_ready (4.1.0)
+    cable_ready (4.1.1)
       rails (>= 5.2)
     coderay (1.1.2)
     concurrent-ruby (1.1.6)

--- a/javascript/consumer.js
+++ b/javascript/consumer.js
@@ -1,15 +1,5 @@
 import { createConsumer } from '@rails/actioncable'
 
-function connectionOpened () {
-  document.body.removeAttribute('data-action-cable-disconnected')
-  document.body.setAttribute('data-action-cable-connected', '')
-}
-
-function connectionClosed () {
-  document.body.removeAttribute('data-action-cable-connected')
-  document.body.setAttribute('data-action-cable-disconnected', '')
-}
-
 function isConsumer (object) {
   if (object) {
     try {
@@ -31,27 +21,6 @@ function findConsumer (object, depth = 0) {
   return Object.values(object)
     .map(o => findConsumer(o, depth + 1))
     .find(o => o)
-}
-
-export function registerConsumer (consumer) {
-  const connection = consumer ? consumer.connection : null
-  const socket = connection ? connection.webSocket : null
-  try {
-    socket.removeEventListener('open', connectionOpened)
-    socket.addEventListener('open', connectionOpened)
-    socket.removeEventListener('close', connectionClosed)
-    socket.addEventListener('close', connectionClosed)
-    socket.removeEventListener('error', connectionClosed)
-    socket.addEventListener('error', connectionClosed)
-    connection.isOpen() ? connectionOpened() : connectionClosed()
-  } catch (error) {
-    console.error(
-      "StimulusReflex was unable to register the ActionCable consumer. Don't worry, everything should still work.",
-      consumer,
-      connection,
-      socket
-    )
-  }
 }
 
 export function getConsumer () {

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stimulus_reflex",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Build reactive applications with the Rails tooling you already know and love.",
   "keywords": [
     "ruby",

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -2,7 +2,7 @@ import { Controller } from 'stimulus'
 import CableReady from 'cable_ready'
 import { v4 as uuidv4 } from 'uuid'
 import { defaultSchema } from './schema'
-import { getConsumer, registerConsumer } from './consumer'
+import { getConsumer } from './consumer'
 import { dispatchLifecycleEvent } from './lifecycle'
 import { allReflexControllers } from './controllers'
 import {
@@ -50,8 +50,6 @@ const resetImplicitReflexPermanent = event => {
 //
 const createSubscription = controller => {
   actionCableConsumer = actionCableConsumer || getConsumer()
-  registerConsumer(actionCableConsumer)
-
   const { channel } = controller.StimulusReflex
   const identifier = JSON.stringify({ channel })
 

--- a/javascript/yarn.lock
+++ b/javascript/yarn.lock
@@ -1209,9 +1209,9 @@ buffer-from@^1.0.0:
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
 "cable_ready@>= 4.1":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/cable_ready/-/cable_ready-4.1.0.tgz#ddf15d341326058b412964716e7d58de4e223cc8"
-  integrity sha512-qNjcOoGbYiVITyfxTIk9AHDkdinbDAMvQ1U4vQgmojZN1n6qeZiMJsqLaqC78BaXPphcDgZVQu83O6FKVf8Cgg==
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/cable_ready/-/cable_ready-4.1.1.tgz#fd73b5135f078d83ed6e6788222a031efd8328b3"
+  integrity sha512-MqCvG6ebXbZDQSI6EcjHEg6IV1lcbGC4We84TAJC6T2MYJAtT6VGEnvT4251qkiLtCyd8A6UpQupsgTjQkxwyA==
   dependencies:
     morphdom "^2.5.12"
 


### PR DESCRIPTION
# Fix

## Description

Remove unneeded registerConsumer logic. This was emitting a console error/warning that confuses users of the library.

The original goal was to make it a little simpler to detect if the ActionCable web socket connection was ready for use; however, it also assumed that there was only a single web socket connection (a detail that is application specific). While a single web socket may be the common case, we should not assume that this is how all Rails + ActionCable applications are structured.

Fixes #156

## Why should this be added

The error/warning confuses users and causes undue concern for a non critical feature.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing