### PR TITLE
add reflex callbacks

### DIFF
--- a/lib/stimulus_reflex/channel.rb
+++ b/lib/stimulus_reflex/channel.rb
@@ -55,9 +55,9 @@ class StimulusReflex::Channel < ActionCable::Channel::Base
     optional_params = method.parameters.select { |(kind, _)| kind == :opt }
 
     if arguments.size == 0 && required_params.size == 0
-      reflex.public_send method_name
+      reflex.process_action(method_name)
     elsif arguments.size >= required_params.size && arguments.size <= required_params.size + optional_params.size
-      reflex.public_send method_name, *arguments
+      reflex.process_action(method_name, *arguments)
     else
       raise ArgumentError.new("wrong number of arguments (given #{arguments.inspect}, expected #{required_params.inspect}, optional #{optional_params.inspect})")
     end

--- a/lib/stimulus_reflex/channel.rb
+++ b/lib/stimulus_reflex/channel.rb
@@ -28,7 +28,7 @@ class StimulusReflex::Channel < ActionCable::Channel::Base
     begin
       reflex_class = reflex_name.constantize
       raise ArgumentError.new("#{reflex_name} is not a StimulusReflex::Reflex") unless is_reflex?(reflex_class)
-      reflex = reflex_class.new(self, url: url, element: element, selectors: selectors)
+      reflex = reflex_class.new(self, url: url, element: element, selectors: selectors, reflex_name: method_name)
       delegate_call_to_reflex reflex, method_name, arguments
     rescue => invoke_error
       message = exception_message_with_backtrace(invoke_error)
@@ -55,9 +55,9 @@ class StimulusReflex::Channel < ActionCable::Channel::Base
     optional_params = method.parameters.select { |(kind, _)| kind == :opt }
 
     if arguments.size == 0 && required_params.size == 0
-      reflex.process_action(method_name)
+      reflex.process_reflex(method_name)
     elsif arguments.size >= required_params.size && arguments.size <= required_params.size + optional_params.size
-      reflex.process_action(method_name, *arguments)
+      reflex.process_reflex(method_name, *arguments)
     else
       raise ArgumentError.new("wrong number of arguments (given #{arguments.inspect}, expected #{required_params.inspect}, optional #{optional_params.inspect})")
     end


### PR DESCRIPTION
# Feature

## Description

- Add Reflex callbacks: `before_reflex`, `around_reflex` , `after_reflex`.
- All callbacks can receive multiple method names, an optional block and the following options: `only`, `except`, `if`, `unless`.
- Can halt a reflex via `throw :abort` in a `before_reflex` callback. Added by @hopsoft.

Examples:
```rb
class ExampleReflex < StimulusReflex::Reflex
  # will run only if the element has the step attribute, can use "unless" instead of "if" for opposite condition
  before_reflex :do_stuff, if: proc { |reflex| reflex.element.dataset[:step] }

  # will run only if the reflex instance has a url attribute, can use "unless" instead of "if" for opposite condition
  before_reflex :do_stuff, if: :url

  # will run before all reflexes
  before_reflex :do_stuff

  # will run before increment reflex, can use "except" instead of "only" for opposite condition
  before_reflex :do_stuff, only: [:increment]

  # will run around all reflexes, must have a yield in the callback
  around_reflex :do_stuff_around

 # will run after all reflexes
  after_reflex :do_stuff

  # Example with a block
  before_reflex do 
    # callback logic
  end

  # Example with multiple method names
  before_reflex :do_stuff, :do_stuff2

  # Example with halt
  before_reflex :run_checks

  def increment
    # reflex logic
  end

  def decrement
    # reflex logic
  end

  private

  def run_checks
    throw :abort # this will prevent the reflex from re-rendering the page
  end

  def do_stuff
    # callback logic
  end

  def do_stuff2
    # callback logic
  end

  def do_stuff_around
    # before
    yield
    # after
  end
end
```

## Why should this be added
https://stimulus-reflex.discourse.group/t/server-side-reflex-callbacks/26

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
