### PR TITLE
add console log messages for every reflex call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,7 +108,6 @@
 **Implemented enhancements:**
 
 - Commit session after rerendering page [\#124](https://github.com/hopsoft/stimulus_reflex/pull/124) ([hopsoft](https://github.com/hopsoft))
-- Propose post install message [\#122](https://github.com/hopsoft/stimulus_reflex/pull/122) ([julianrubisch](https://github.com/julianrubisch))
 
 ## [v2.2.1](https://github.com/hopsoft/stimulus_reflex/tree/v2.2.1) (2020-02-28)
 
@@ -166,6 +165,7 @@
 
 **Implemented enhancements:**
 
+- Propose post install message [\#122](https://github.com/hopsoft/stimulus_reflex/pull/122) ([julianrubisch](https://github.com/julianrubisch))
 - StimulusReflex::Channel - Error messages include stack trace info [\#100](https://github.com/hopsoft/stimulus_reflex/pull/100) ([szTheory](https://github.com/szTheory))
 
 **Closed issues:**
@@ -182,6 +182,7 @@
 - Add schema support [\#94](https://github.com/hopsoft/stimulus_reflex/pull/94) ([hopsoft](https://github.com/hopsoft))
 - inherit stimulus schema [\#92](https://github.com/hopsoft/stimulus_reflex/pull/92) ([nickyvanurk](https://github.com/nickyvanurk))
 - Single source of truth [\#76](https://github.com/hopsoft/stimulus_reflex/pull/76) ([leastbad](https://github.com/leastbad))
+- Update installer [\#71](https://github.com/hopsoft/stimulus_reflex/pull/71) ([hopsoft](https://github.com/hopsoft))
 
 **Fixed bugs:**
 
@@ -213,7 +214,6 @@
 **Implemented enhancements:**
 
 - Create Rails generators [\#3](https://github.com/hopsoft/stimulus_reflex/issues/3)
-- Update installer [\#71](https://github.com/hopsoft/stimulus_reflex/pull/71) ([hopsoft](https://github.com/hopsoft))
 - Tweak generators [\#69](https://github.com/hopsoft/stimulus_reflex/pull/69) ([hopsoft](https://github.com/hopsoft))
 - add generators [\#67](https://github.com/hopsoft/stimulus_reflex/pull/67) ([andrewmcodes](https://github.com/andrewmcodes))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## [Unreleased](https://github.com/hopsoft/stimulus_reflex/tree/HEAD)
+## [v3.1.3](https://github.com/hopsoft/stimulus_reflex/tree/v3.1.3) (2020-04-20)
 
-[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v3.1.2...HEAD)
+[Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v3.1.2...v3.1.3)
 
 **Implemented enhancements:**
 
@@ -108,6 +108,7 @@
 **Implemented enhancements:**
 
 - Commit session after rerendering page [\#124](https://github.com/hopsoft/stimulus_reflex/pull/124) ([hopsoft](https://github.com/hopsoft))
+- Propose post install message [\#122](https://github.com/hopsoft/stimulus_reflex/pull/122) ([julianrubisch](https://github.com/julianrubisch))
 
 ## [v2.2.1](https://github.com/hopsoft/stimulus_reflex/tree/v2.2.1) (2020-02-28)
 
@@ -165,7 +166,6 @@
 
 **Implemented enhancements:**
 
-- Propose post install message [\#122](https://github.com/hopsoft/stimulus_reflex/pull/122) ([julianrubisch](https://github.com/julianrubisch))
 - StimulusReflex::Channel - Error messages include stack trace info [\#100](https://github.com/hopsoft/stimulus_reflex/pull/100) ([szTheory](https://github.com/szTheory))
 
 **Closed issues:**
@@ -182,7 +182,6 @@
 - Add schema support [\#94](https://github.com/hopsoft/stimulus_reflex/pull/94) ([hopsoft](https://github.com/hopsoft))
 - inherit stimulus schema [\#92](https://github.com/hopsoft/stimulus_reflex/pull/92) ([nickyvanurk](https://github.com/nickyvanurk))
 - Single source of truth [\#76](https://github.com/hopsoft/stimulus_reflex/pull/76) ([leastbad](https://github.com/leastbad))
-- Update installer [\#71](https://github.com/hopsoft/stimulus_reflex/pull/71) ([hopsoft](https://github.com/hopsoft))
 
 **Fixed bugs:**
 
@@ -214,6 +213,7 @@
 **Implemented enhancements:**
 
 - Create Rails generators [\#3](https://github.com/hopsoft/stimulus_reflex/issues/3)
+- Update installer [\#71](https://github.com/hopsoft/stimulus_reflex/pull/71) ([hopsoft](https://github.com/hopsoft))
 - Tweak generators [\#69](https://github.com/hopsoft/stimulus_reflex/pull/69) ([hopsoft](https://github.com/hopsoft))
 - add generators [\#67](https://github.com/hopsoft/stimulus_reflex/pull/67) ([andrewmcodes](https://github.com/andrewmcodes))
 
@@ -320,6 +320,7 @@
 - Implicitly send DOM attributes to reflex methods [\#21](https://github.com/hopsoft/stimulus_reflex/pull/21) ([hopsoft](https://github.com/hopsoft))
 - Add Ruby magic comment [\#18](https://github.com/hopsoft/stimulus_reflex/pull/18) ([dixpac](https://github.com/dixpac))
 - Add GitHub Actions for Linters [\#17](https://github.com/hopsoft/stimulus_reflex/pull/17) ([andrewmcodes](https://github.com/andrewmcodes))
+- Add support for rooms [\#11](https://github.com/hopsoft/stimulus_reflex/pull/11) ([hopsoft](https://github.com/hopsoft))
 
 **Fixed bugs:**
 
@@ -336,10 +337,6 @@
 ## [v1.0.1](https://github.com/hopsoft/stimulus_reflex/tree/v1.0.1) (2019-08-10)
 
 [Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v1.0.0...v1.0.1)
-
-**Implemented enhancements:**
-
-- Add support for rooms [\#11](https://github.com/hopsoft/stimulus_reflex/pull/11) ([hopsoft](https://github.com/hopsoft))
 
 **Closed issues:**
 

--- a/javascript/log.js
+++ b/javascript/log.js
@@ -17,17 +17,24 @@ function request (
 }
 
 function success (response) {
-  const { event, events, element } = response || {}
-  const { detail } = event || {}
-  const { html } = detail || {}
-  const { reflexId, target, last } = detail.stimulusReflex || {}
+  const html = {}
+  const payloads = {}
+  const elements = {}
+  const { event, events } = response
+  const { reflexId, target, last } = event.detail.stimulusReflex || {}
+
+  Object.keys(events).map(selector => {
+    elements[selector] = events[selector].detail.element
+    html[selector] = events[selector].detail.html
+    payloads[selector] = events[selector].detail.stimulusReflex
+  })
+
   console.log(`\u2B05 ${target}`, {
     reflexId,
     duration: `${new Date() - logs[reflexId]}ms`,
-    payload: event.detail.stimulusReflex,
-    element,
-    html,
-    events
+    elements,
+    payloads,
+    html
   })
   if (last) delete logs[reflexId]
 }

--- a/javascript/log.js
+++ b/javascript/log.js
@@ -1,27 +1,109 @@
+const logs = {}
+
 const colors = {
-  default: 'inherit',
   gray: '#9E9E9E',
   blue: '#03A9F4',
+  darkblue: '#0040f5',
   green: '#4CAF50',
-  red: '#F20404'
+  red: '#F20404',
+  purple: '#97288a',
+  magenta: '#eb59f7',
+  orange: '#f19737',
+  random: () => {
+    return '#' + Math.floor(Math.random() * 200 * 200 * 200).toString(16)
+  }
 }
 
-function styleFor (name) {
-  return `color: ${colors[name]}; font-weight: bold`
+function style (color = 'inherit', weight = 'normal', background = 'none') {
+  return `color: ${color}; font-weight: ${weight}; background: ${background}`
 }
 
-export function logReflex (id, controller, target, element, argument) {
-  const title = `%c stimulate %c ${target} %c@ ${new Date()}`
-  const grayLight = 'color: gray; font-weight: light;'
-  const defaultBold = 'color: inherit; font-weight: bold;'
+function request (id, target, controller, element, argument) {
+  const color = colors.random()
+  const triggerdAt = new Date()
 
-  console.groupCollapsed(title, grayLight, defaultBold, grayLight)
+  const title = `%cstimulate ==> %c${target} %c- %c${id}`
+  const styles = [
+    style('gray'),
+    style('inherit', 'bold'),
+    style('gray'),
+    style(color)
+  ]
 
+  console.groupCollapsed(title, ...styles)
   console.log('%c id', styleFor('default'), id)
-  console.log('%c controller', styleFor('gray'), controller)
+  console.log('%c date', styleFor('gray'), triggerdAt)
   console.log('%c target', styleFor('blue'), target)
+  console.log('%c controller', styleFor('purple'), controller)
   console.log('%c element', styleFor('green'), element)
-  console.log('%c argument', styleFor('red'), argument)
-
+  console.log('%c argument', styleFor('magenta'), argument)
   console.groupEnd()
+
+  logs[id] = { color, triggerdAt, count: 1 }
+}
+
+function response (response) {
+  const { reflexId, target, url, last } = response.event.detail.stimulusReflex || {}
+  const { html, selector } = response.event.detail || {}
+  const { color, triggerdAt, count } = logs[reflexId] || {}
+  const receivedAt = new Date()
+  const responseCount = (!last || count > 1) ? `[${count}]` : ''
+
+  const title = `%cstimulate <== %c${target} %c- %c${reflexId} %c(${receivedAt - triggerdAt}ms) ${responseCount}`
+  const styles = [
+    style('gray'),
+    style('inherit', 'bold'),
+    style('gray'),
+    style(color),
+    style('gray')
+  ]
+
+  console.groupCollapsed(title, ...styles)
+  console.log('%c id', style(colors.default, 'bold'), reflexId)
+  console.log('%c date', style(colors.gray, 'bold'), receivedAt)
+  console.log('%c target', style(colors.blue, 'bold'), target)
+  console.log('%c selector', style(colors.purple, 'bold'), selector)
+  console.log('%c html', style(colors.green, 'bold'), html)
+  console.log('%c url', style(colors.magenta, 'bold'), url)
+  console.log('%c event', style(colors.orange, 'bold'), event)
+  console.groupEnd()
+
+  if (last) {
+    delete logs[reflexId]
+  } else {
+    logs[reflexId].count += 1
+  }
+}
+
+function error (response) {
+  const { reflexId, target, selectors, error, url } = response.event.detail.stimulusReflex || {}
+  const { color, triggerdAt } = logs[reflexId] || {}
+  const receivedAt = new Date()
+
+  const title = `%cstimulate <== %c${target} %c- %c${reflexId} %c(${receivedAt - triggerdAt}ms) [error]`
+  const styles = [
+    style('gray', 'normal', '#fceceb'),
+    style('inherit', 'bold', '#fceceb'),
+    style('gray', 'normal', '#fceceb'),
+    style(color, 'normal', '#fceceb'),
+    style('gray', 'normal', '#fceceb')
+  ]
+
+  console.groupCollapsed(title, ...styles)
+  console.error('%c id', style('black', 'bold'), reflexId)
+  console.error('%c date', style(colors.gray, 'bold'), receivedAt)
+  console.error('%c error', style('inherit', 'bold'), error)
+  console.error('%c target', style(colors.blue, 'bold'), target)
+  console.error('%c selectors', style(colors.purple, 'bold'), selectors)
+  console.error('%c url', style(colors.magenta, 'bold'), url)
+  console.error('%c event', style(colors.orange, 'bold'), event)
+  console.groupEnd()
+
+  delete logs[reflexId]
+}
+
+export default {
+  request,
+  response,
+  error
 }

--- a/javascript/log.js
+++ b/javascript/log.js
@@ -43,13 +43,15 @@ function request (id, target, controller, element, argument) {
 }
 
 function response (response) {
-  const { reflexId, target, url, last } = response.event.detail.stimulusReflex || {}
+  const { reflexId, target, url, last } =
+    response.event.detail.stimulusReflex || {}
   const { html, selector } = response.event.detail || {}
   const { color, triggerdAt, count } = logs[reflexId] || {}
   const receivedAt = new Date()
-  const responseCount = (!last || count > 1) ? `[${count}]` : ''
+  const responseCount = !last || count > 1 ? `[${count}]` : ''
 
-  const title = `%cstimulate <== %c${target} %c- %c${reflexId} %c(${receivedAt - triggerdAt}ms) ${responseCount}`
+  const title = `%cstimulate <== %c${target} %c- %c${reflexId} %c(${receivedAt -
+    triggerdAt}ms) ${responseCount}`
   const styles = [
     style('gray'),
     style('inherit', 'bold'),
@@ -76,11 +78,13 @@ function response (response) {
 }
 
 function error (response) {
-  const { reflexId, target, selectors, error, url } = response.event.detail.stimulusReflex || {}
+  const { reflexId, target, selectors, error, url } =
+    response.event.detail.stimulusReflex || {}
   const { color, triggerdAt } = logs[reflexId] || {}
   const receivedAt = new Date()
 
-  const title = `%cstimulate <== %c${target} %c- %c${reflexId} %c(${receivedAt - triggerdAt}ms) [error]`
+  const title = `%cstimulate <== %c${target} %c- %c${reflexId} %c(${receivedAt -
+    triggerdAt}ms) [error]`
   const styles = [
     style('gray', 'normal', '#fceceb'),
     style('inherit', 'bold', '#fceceb'),

--- a/javascript/log.js
+++ b/javascript/log.js
@@ -1,0 +1,27 @@
+const colors = {
+  default: 'inherit',
+  gray: '#9E9E9E',
+  blue: '#03A9F4',
+  green: '#4CAF50',
+  red: '#F20404'
+}
+
+function styleFor (name) {
+  return `color: ${colors[name]}; font-weight: bold`
+}
+
+export function logReflex (id, controller, target, element, argument) {
+  const title = `%c stimulate %c ${target} %c@ ${new Date()}`
+  const grayLight = 'color: gray; font-weight: light;'
+  const defaultBold = 'color: inherit; font-weight: bold;'
+
+  console.groupCollapsed(title, grayLight, defaultBold, grayLight)
+
+  console.log('%c id', styleFor('default'), id)
+  console.log('%c controller', styleFor('gray'), controller)
+  console.log('%c target', styleFor('blue'), target)
+  console.log('%c element', styleFor('green'), element)
+  console.log('%c argument', styleFor('red'), argument)
+
+  console.groupEnd()
+}

--- a/javascript/log.js
+++ b/javascript/log.js
@@ -31,12 +31,12 @@ function request (id, target, controller, element, argument) {
   ]
 
   console.groupCollapsed(title, ...styles)
-  console.log('%c id', styleFor('default'), id)
-  console.log('%c date', styleFor('gray'), triggerdAt)
-  console.log('%c target', styleFor('blue'), target)
-  console.log('%c controller', styleFor('purple'), controller)
-  console.log('%c element', styleFor('green'), element)
-  console.log('%c argument', styleFor('magenta'), argument)
+  console.log('%c id', style('inherit', 'bold'), id)
+  console.log('%c date', style(colors.gray, 'bold'), triggerdAt)
+  console.log('%c target', style(colors.blue, 'bold'), target)
+  console.log('%c controller', style(colors.purple, 'bold'), controller)
+  console.log('%c element', style(colors.green, 'bold'), element)
+  console.log('%c argument', style(colors.magenta, 'bold'), argument)
   console.groupEnd()
 
   logs[id] = { color, triggerdAt, count: 1 }

--- a/javascript/log.js
+++ b/javascript/log.js
@@ -19,12 +19,14 @@ function request (
 function success (response) {
   const { event, element } = response || {}
   const { detail } = event || {}
+  const { html } = detail || {}
   const { reflexId, target, last } = detail.stimulusReflex || {}
   console.log(`\u2B05 ${target}`, {
     reflexId,
     duration: `${new Date() - logs[reflexId]}ms`,
     payload: event.detail.stimulusReflex,
-    element
+    element,
+    html
   })
   if (last) delete logs[reflexId]
 }

--- a/javascript/log.js
+++ b/javascript/log.js
@@ -17,7 +17,7 @@ function request (
 }
 
 function success (response) {
-  const { event, element } = response || {}
+  const { event, events, element } = response || {}
   const { detail } = event || {}
   const { html } = detail || {}
   const { reflexId, target, last } = detail.stimulusReflex || {}
@@ -26,7 +26,8 @@ function success (response) {
     duration: `${new Date() - logs[reflexId]}ms`,
     payload: event.detail.stimulusReflex,
     element,
-    html
+    html,
+    events
   })
   if (last) delete logs[reflexId]
 }

--- a/javascript/options.js
+++ b/javascript/options.js
@@ -1,0 +1,3 @@
+export const defaultOptions = {
+  logging: false
+}

--- a/javascript/options.js
+++ b/javascript/options.js
@@ -1,3 +1,0 @@
-export const defaultOptions = {
-  logging: false
-}

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stimulus_reflex",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Build reactive applications with the Rails tooling you already know and love.",
   "keywords": [
     "ruby",

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -130,7 +130,7 @@ const extendStimulusController = controller => {
       const promise = new Promise(
         (resolve, reject) => (promises[reflexId] = { resolve, reject, data })
       )
-      promise.catch(() => {}) // noop default catch
+      if (debugging) promise.catch(() => {}) // noop default catch
       return promise
     },
 

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -321,7 +321,7 @@ if (!document.stimulusReflexInitialized) {
 
     const element = findElement(attrs)
     const promise = promises[event.detail.stimulusReflex.reflexId]
-    const response = { data: promise?.data, element, event }
+    const response = { data: (promise && promise.data), element, event }
 
     if (options.logging) {
       Log.response(response)

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -5,6 +5,7 @@ import { defaultSchema } from './schema'
 import { getConsumer } from './consumer'
 import { dispatchLifecycleEvent } from './lifecycle'
 import { allReflexControllers } from './controllers'
+import { logReflex } from './log'
 import {
   attributeValue,
   attributeValues,
@@ -129,6 +130,9 @@ const extendStimulusController = controller => {
       element.reflexData = data
 
       dispatchLifecycleEvent('before', element)
+
+      logReflex(reflexId, this.context.scope.identifier, target, element, args[0])
+
       subscription.send(data)
 
       return new Promise((resolve, reject) => {

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -2,6 +2,7 @@ import { Controller } from 'stimulus'
 import CableReady from 'cable_ready'
 import { v4 as uuidv4 } from 'uuid'
 import { defaultSchema } from './schema'
+import { defaultOptions } from './options'
 import { getConsumer } from './consumer'
 import { dispatchLifecycleEvent } from './lifecycle'
 import { allReflexControllers } from './controllers'
@@ -131,7 +132,9 @@ const extendStimulusController = controller => {
 
       dispatchLifecycleEvent('before', element)
 
-      logReflex(reflexId, this.context.scope.identifier, target, element, args[0])
+      if (stimulusApplication.options.logging) {
+        logReflex(reflexId, this.context.scope.identifier, target, element, args[0])
+      }
 
       subscription.send(data)
 
@@ -270,16 +273,26 @@ const getReflexRoots = element => {
 // - options
 //   * controller - [optional] the default StimulusReflexController
 //   * consumer - [optional] the ActionCable consumer
+//   * logging - [optional] option wheter reflex logging should be enabled or not
 //
 const initialize = (application, options = {}) => {
   const { controller, consumer } = options
   actionCableConsumer = consumer
   stimulusApplication = application
+  stimulusApplication.options = { ...defaultOptions, ...options }
   stimulusApplication.schema = { ...defaultSchema, ...application.schema }
   stimulusApplication.register(
     'stimulus-reflex',
     controller || StimulusReflexController
   )
+}
+
+const enableLogging = () => {
+  stimulusApplication.options.logging = true
+}
+
+const disableLogging = () => {
+  stimulusApplication.options.logging = false
 }
 
 if (!document.stimulusReflexInitialized) {
@@ -325,4 +338,9 @@ if (!document.stimulusReflexInitialized) {
   document.addEventListener('focusout', resetImplicitReflexPermanent)
 }
 
-export default { initialize, register }
+export default {
+  initialize,
+  register,
+  enableLogging,
+  disableLogging
+}

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -296,17 +296,18 @@ if (!document.stimulusReflexInitialized) {
     const { attrs, last } = event.detail.stimulusReflex || {}
     const element = findElement(attrs)
     const promise = promises[event.detail.stimulusReflex.reflexId]
+    const response = { data: promise && promise.data, element, event }
+
+    if (debugging) Log.success(response)
 
     if (!last) return
 
-    const response = { data: promise && promise.data, element, event }
     if (promise) {
       delete promises[event.detail.stimulusReflex.reflexId]
       promise.resolve(response)
     }
 
     dispatchLifecycleEvent('success', element)
-    if (debugging) Log.success(response)
   })
   document.addEventListener('stimulus-reflex:500', event => {
     const { reflexId, attrs, error } = event.detail.stimulusReflex || {}

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -141,15 +141,21 @@ const extendStimulusController = controller => {
 
       const promise = new Promise((resolve, reject) => {
         promises[reflexId] = { resolve, reject, data }
-      });
+      })
 
       if (options.logging) {
-        Log.request(reflexId, target, this.context.scope.identifier, element, args[0])
+        Log.request(
+          reflexId,
+          target,
+          this.context.scope.identifier,
+          element,
+          args[0]
+        )
         // promise.then(response => Log.response(response));
-        promise.catch(response => Log.error(response));
+        promise.catch(response => Log.error(response))
       }
 
-      return promise;
+      return promise
     },
 
     // Wraps the call to stimulate for any data-reflex elements.
@@ -321,7 +327,7 @@ if (!document.stimulusReflexInitialized) {
 
     const element = findElement(attrs)
     const promise = promises[event.detail.stimulusReflex.reflexId]
-    const response = { data: (promise && promise.data), element, event }
+    const response = { data: promise && promise.data, element, event }
 
     if (options.logging) {
       Log.response(response)
@@ -347,7 +353,12 @@ if (!document.stimulusReflexInitialized) {
 
     if (promise) {
       delete promises[event.detail.stimulusReflex.reflexId]
-      promise.reject({ data: promise.data, element, event, toString: () => error })
+      promise.reject({
+        data: promise.data,
+        element,
+        event,
+        toString: () => error
+      })
     }
 
     dispatchLifecycleEvent('error', element)


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Enhancement

## Description

This PR adds logging functionality to show which reflexes were called and what data was sent to the backend. 

This is heavily inspired by https://github.com/LogRocket/redux-logger

## Screenshot

![log-reflex](https://user-images.githubusercontent.com/6411752/79925534-e305d000-843a-11ea-9dc7-646edc59592f.png)

## Why should this be added

I think this is useful for debugging and tracing purposes. For example if you want to know what data was sent to the reflex or in which order the reflexes were called.

## Discussion points
- [x] Maybe it makes sense to provide an option to disable the functionality completely (for example in the production environment or based on a log level) 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
