### PR TITLE
Fix compilation issue

### DIFF
--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -59,9 +59,9 @@ const createSubscription = controller => {
       received: data => {
         if (!data.cableReady) return
         if (data.operations.morph && data.operations.morph.length) {
-          const urls = [
-            ...new Set(data.operations.morph.map(m => m.stimulusReflex.url))
-          ]
+          const urls = Array.from(
+            new Set(data.operations.morph.map(m => m.stimulusReflex.url))
+          )
           if (urls.length !== 1 || urls[0] !== location.href) return
         }
         CableReady.perform(data.operations)


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)
A bug fix that fixes #166 

## Description
When trying to compile the stimulus-reflex on my end urls end up as an array of sets rather than as an array of strings. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
