### PR TITLE
setupDeclarativeReflexes export with UJS support

### DIFF
--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -287,6 +287,9 @@ if (!document.stimulusReflexInitialized) {
   document.addEventListener('cable-ready:after-morph', () =>
     setTimeout(setupDeclarativeReflexes, 1)
   )
+  document.addEventListener('ajax:complete', () =>
+    setTimeout(setupDeclarativeReflexes, 1)
+  )
   // Trigger success and after lifecycle methods from before-morph to ensure we can find a reference
   // to the source element in case it gets removed from the DOM via morph.
   // This is safe because the server side reflex completed successfully.
@@ -321,4 +324,4 @@ if (!document.stimulusReflexInitialized) {
   document.addEventListener('focusout', resetImplicitReflexPermanent)
 }
 
-export default { initialize, register }
+export default { initialize, register, setupDeclarativeReflexes }


### PR DESCRIPTION
# Enhancement

Scan DOM for `data-reflex` attributes after UJS operations.

Also export `setupDeclarativeReflexes` so that it can be called from a controller that utilizes a template engine.

Fixes #161 

## Why should this be added

Cover a new use case and make the library more flexible.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
