### PR TITLE
Support devise authenticated routes

### DIFF
--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -17,9 +17,8 @@ class StimulusReflex::Reflex
     @request ||= begin
       uri = URI.parse(url)
       path = ActionDispatch::Journey::Router::Utils.normalize_path(uri.path)
-      path_params = Rails.application.routes.recognize_path(path)
       query_hash = Rack::Utils.parse_nested_query(uri.query)
-      ActionDispatch::Request.new(
+      req = ActionDispatch::Request.new(
         connection.env.merge(
           Rack::MockRequest.env_for(uri.to_s).merge(
             "rack.request.query_hash" => query_hash,
@@ -29,11 +28,13 @@ class StimulusReflex::Reflex
             Rack::SCRIPT_NAME => "",
             Rack::PATH_INFO => path,
             Rack::REQUEST_PATH => path,
-            Rack::QUERY_STRING => uri.query,
-            ActionDispatch::Http::Parameters::PARAMETERS_KEY => path_params
+            Rack::QUERY_STRING => uri.query
           )
         )
-      ).tap { |req| req.session.send :load! }
+      )
+      path_params = Rails.application.routes.recognize_path_with_request(req, url, req.env[:extras] || {})
+      req.env.merge(ActionDispatch::Http::Parameters::PARAMETERS_KEY => path_params)
+      req.tap { |r| r.session.send :load! }
     end
   end
 


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bug fix

## Description

According to this PR https://github.com/hopsoft/stimulus_reflex/pull/105 , the devise authenticated routes were supposed to be supported. But I have the feeling that the rewriting of some code with the newest versions introduced this issue once again.

I tried to implement a fix to highlight were the problem is according to me. But I'm not over confident on these topics (request, action dispatch...), so I solved it in a (too?) simple way. Hope this can be helpful.

The main thing I don't like in my code is calling `Rails.application.routes.recognize_path_with_request` once again, in addition to `StimulusReflex::Reflex#url_params`. But at this stage, I'm not sure how to avoid this call.

Happy to discuss it with you, and see how we can improve this, or, find how to solve this issue in another way.

Fixes #173 

## Why should this be added

Authenticated devise routes are quite common in the rails project. Not supporting this would require developers to find workarounds of not using, say, a specific `root_path` for their authenticated users. It has been fixed once by @hopsoft , so I guess we should re-introduce it again.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
