### PR TITLE
Fix bug in super documentation

### DIFF
--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -42,7 +42,7 @@ import ApplicationController from './application_controller'
 
 export default class extends ApplicationController {
   sayHi () {
-    super()
+    super.sayHi()
     console.log('Hello from a Custom controller')
   }
 }
@@ -50,7 +50,7 @@ export default class extends ApplicationController {
 {% endtab %}
 {% endtabs %}
 
-If you need to override any methods on your ApplicationController, you can redefine them. Optionally call `super(...Array.from(arguments))` to invoke the method on the parent super class.
+If you need to override any methods on your ApplicationController, you can redefine them. Optionally call `super.AnyMethod(...Array.from(arguments))` to invoke the method on the parent super class.
 
 ### Benchmarking your Reflex actions
 


### PR DESCRIPTION

# Type of PR (feature, enhancement, bug fix, etc.)
Documentation fix
## Description

Calling super() from child class raises this error in javascript

```
super() is only valid inside a class constructor of a subclass. Maybe a typo in the method name ('constructor') or not extending another class?
```

## Why should this be added
 because it is inaccurate

## Checklist

- [ x] My code follows the style guidelines of this project
- [ x] Checks (StandardRB & Prettier-Standard) are passing
