### PR TITLE
prettier-standard: include all js files in the project

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -29,8 +29,8 @@
   "main": "./stimulus_reflex.js",
   "scripts": {
     "postinstall": "node scripts/post_install.js",
-    "prettier-standard:check": "yarn run prettier-standard --check ./**/*.js",
-    "prettier-standard:format": "yarn run prettier-standard ./**/*.js",
+    "prettier-standard:check": "yarn run prettier-standard --check *.js **/*.js",
+    "prettier-standard:format": "yarn run prettier-standard *.js **/*.js",
     "test": "yarn run mocha --require @babel/register"
   },
   "dependencies": {


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Enhancement (DX)

## Description

Seems like that the `prettier-standard` scripts in `package.json` do not check/format every .js file in the project.

On current master:

```bash
stimulus_reflex/javascript on master is 📦 v3.1.3 via ⬢ v10.15.1
❯ yarn run prettier-standard:format                                                                                                23:39:07
yarn run v1.22.4
$ yarn run prettier-standard ./**/*.js
$ /Users/marcoroth/Development/stimulus_reflex/javascript/node_modules/.bin/prettier-standard ./node_modules/decimal.js ./scripts/post_install.js ./test/attributes.attributeValue.test.js ./test/attributes.attributeValues.test.js ./test/attributes.extractElementAttributes.test.js ./test/refute.js
scripts/post_install.js 45ms
test/attributes.attributeValue.test.js 13ms
test/attributes.attributeValues.test.js 8ms
test/attributes.extractElementAttributes.test.js 22ms
test/refute.js 6ms
✨  Done in 1.17s.
```

On this PR branch:

```bash
stimulus_reflex/javascript on prettier-check-all-files is 📦 v3.1.3 via ⬢ v10.15.1
❯ yarn run prettier-standard:format                                                                                                23:37:44
yarn run v1.22.4
$ yarn run prettier-standard *.js **/*.js
$ /Users/marcoroth/Development/stimulus_reflex/javascript/node_modules/.bin/prettier-standard attributes.js consumer.js controllers.js lifecycle.js schema.js stimulus_reflex.js node_modules/decimal.js scripts/post_install.js test/attributes.attributeValue.test.js test/attributes.attributeValues.test.js test/attributes.extractElementAttributes.test.js test/refute.js
attributes.js 72ms
consumer.js 10ms
controllers.js 7ms
lifecycle.js 24ms
schema.js 4ms
stimulus_reflex.js 68ms
scripts/post_install.js 10ms
test/attributes.attributeValue.test.js 7ms
test/attributes.attributeValues.test.js 9ms
test/attributes.extractElementAttributes.test.js 16ms
test/refute.js 3ms
✨  Done in 2.47s.
```

## Why should this be added

It helps contributors to follow the style guidelines so they can just execute the provided npm scripts and be sure their contribution follows the guidelines.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
