### PR TITLE
Allow channel exceptions to be rescuable

### DIFF
--- a/lib/stimulus_reflex/channel.rb
+++ b/lib/stimulus_reflex/channel.rb
@@ -31,6 +31,7 @@ class StimulusReflex::Channel < ActionCable::Channel::Base
       reflex = reflex_class.new(self, url: url, element: element, selectors: selectors)
       delegate_call_to_reflex reflex, method_name, arguments
     rescue => invoke_error
+      reflex.rescue_with_handler(invoke_error)
       message = exception_message_with_backtrace(invoke_error)
       return broadcast_error("StimulusReflex::Channel Failed to invoke #{target}! #{url} #{message}", data)
     end
@@ -38,6 +39,7 @@ class StimulusReflex::Channel < ActionCable::Channel::Base
     begin
       render_page_and_broadcast_morph reflex, selectors, data
     rescue => render_error
+      reflex.rescue_with_handler(render_error)
       message = exception_message_with_backtrace(render_error)
       broadcast_error "StimulusReflex::Channel Failed to re-render #{url} #{message}", data
     end

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class StimulusReflex::Reflex
+  include ActiveSupport::Rescuable
+
   attr_reader :channel, :url, :element, :selectors
 
   delegate :connection, to: :channel


### PR DESCRIPTION
# Feature

## Description

Exceptions in reflexes are currently logged and swallowed. This will give reflexes the ability to handle the exceptions via `rescue_from` in much the same manner as you would with ActionController.

## Why should this be added

We'd like to track reflex errors via an external exception tracker, but the errors are currently swallowed with no chance to handle them.

This PR allows you to use `rescue_from` in reflexes thusly:

```ruby
class MyTestReflex < StimulusReflex::Reflex
  rescue_from StandardError do |exception|
    ExceptionTrackingService.error(exception)
  end

  # ...
end
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
