### PR TITLE
Introduce websocket adapter to stimulusreflex for more flexibility

### DIFF
--- a/javascript/adapter.js
+++ b/javascript/adapter.js
@@ -1,39 +1,31 @@
 import CableReady from 'cable_ready'
 
-class ConsumerAdapter {
+class AbstractConsumerAdapter {
   constructor (consumer) {
     this.consumer = consumer
-  }
-
-  find_subscriptions (identifier) {
-    throw Error('Not implemented')
-  }
-
-  create_subscription (channel) {
-    throw Error('Not implemented')
-  }
-
-  isConnected () {
-    throw Error('Not implemented')
-  }
-
-  send (identifier, data, options = {}) {
-    throw Error('Not implemented')
-  }
-
-  connect () {
-    throw Error('Not implemented')
-  }
-
-  disconnect () {
-    throw Error('Not implemented')
+    if (new.target === AbstractConsumerAdapter) {
+      throw new TypeError('Cannot construct an abstract instance directly')
+    }
+    const methods = [
+      // takes an argument identifier
+      'find_subscription',
+      // takes an argument channel
+      'create_subscription',
+      'isConnected',
+      // takes arguments identifier, data, options
+      'send',
+      'connect',
+      'disconnect'
+    ]
+    for (const method of methods) {
+      if (typeof this[method] === undefined) {
+        throw new TypeError(`Must override the method ${method}`)
+      }
+    }
   }
 }
 
-class ActionCableAdapter extends ConsumerAdapter {
-  constructor (consumer) {
-    this.consumer = consumer
-  }
+class ActionCableAdapter extends AbstractConsumerAdapter {
 
   find_subscription (identifier) {
     return this.consumer.subscriptions.findAll(identifier)[0]
@@ -72,4 +64,4 @@ class ActionCableAdapter extends ConsumerAdapter {
   }
 }
 
-export { ActionCableAdapter, ConsumerAdapter }
+export { ActionCableAdapter, AbstractConsumerAdapter }

--- a/javascript/adapter.js
+++ b/javascript/adapter.js
@@ -25,8 +25,11 @@ class AbstractConsumerAdapter {
   }
 }
 
-class ActionCableAdapter extends AbstractConsumerAdapter {
+const getAbstractClass = () => {
+  return AbstractConsumerAdapter
+}
 
+class ActionCableAdapter extends AbstractConsumerAdapter {
   find_subscription (identifier) {
     return this.consumer.subscriptions.findAll(identifier)[0]
   }
@@ -64,4 +67,4 @@ class ActionCableAdapter extends AbstractConsumerAdapter {
   }
 }
 
-export { ActionCableAdapter, AbstractConsumerAdapter }
+export { ActionCableAdapter, getAbstractClass }

--- a/javascript/adapter.js
+++ b/javascript/adapter.js
@@ -1,0 +1,75 @@
+import CableReady from 'cable_ready'
+
+class ConsumerAdapter {
+  constructor (consumer) {
+    this.consumer = consumer
+  }
+
+  find_subscriptions (identifier) {
+    throw Error('Not implemented')
+  }
+
+  create_subscription (channel) {
+    throw Error('Not implemented')
+  }
+
+  isConnected () {
+    throw Error('Not implemented')
+  }
+
+  send (identifier, data, options = {}) {
+    throw Error('Not implemented')
+  }
+
+  connect () {
+    throw Error('Not implemented')
+  }
+
+  disconnect () {
+    throw Error('Not implemented')
+  }
+}
+
+class ActionCableAdapter extends ConsumerAdapter {
+  constructor (consumer) {
+    this.consumer = consumer
+  }
+
+  find_subscription (identifier) {
+    return this.consumer.subscriptions.findAll(identifier)[0]
+  }
+
+  create_subscription (channel) {
+    this.consumer.subscriptions.create(channel, {
+      received: data => {
+        if (!data.cableReady) return
+        if (data.operations.morph && data.operations.morph.length) {
+          const urls = Array.from(
+            new Set(data.operations.morph.map(m => m.stimulusReflex.url))
+          )
+          if (urls.length !== 1 || urls[0] !== location.href) return
+        }
+        CableReady.perform(data.operations)
+      }
+    })
+  }
+
+  connect () {
+    return this.consumer.connection.open()
+  }
+
+  disconnect () {
+    return this.consumer.connection.close({ allowReconnect: false })
+  }
+
+  isConnected () {
+    return this.consumer.connection.isOpen()
+  }
+
+  send (identifier, data, options = {}) {
+    let subscription = this.find_subscription(identifier)
+    subscription.send(data)
+  }
+}
+
+export { ActionCableAdapter, ConsumerAdapter }

--- a/javascript/consumer.js
+++ b/javascript/consumer.js
@@ -4,7 +4,7 @@ function isConsumer (object) {
   if (object) {
     try {
       return (
-        object.isConnected &&
+        object.constructor.name == 'ActionCableAdapter' &&
         object.connect &&
         object.disconnect &&
         object.send

--- a/javascript/consumer.js
+++ b/javascript/consumer.js
@@ -4,7 +4,7 @@ function isConsumer (object) {
   if (object) {
     try {
       return (
-        object.constructor.name === 'Consumer' &&
+        object.isConnected &&
         object.connect &&
         object.disconnect &&
         object.send

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -1,12 +1,11 @@
 import { Controller } from 'stimulus'
-import CableReady from 'cable_ready'
 import { defaultSchema } from './schema'
 import { getConsumer } from './consumer'
 import { dispatchLifecycleEvent } from './lifecycle'
 import { allReflexControllers } from './controllers'
 import { uuidv4 } from './utils'
 import Log from './log'
-import { ActionCableAdapter } from './adapter'
+import { ActionCableAdapter, getAbstractClass } from './adapter'
 import {
   attributeValue,
   attributeValues,
@@ -58,7 +57,7 @@ const extendStimulusController = controller => {
     // Indicates if the consumer connection is open.
     // The connection must be open before calling stimulate.
     //
-    isConsumerConnectionOpen() {
+    isConsumerConnectionOpen () {
       return this.StimulusReflex.consumer.isConnected()
     },
 
@@ -108,9 +107,7 @@ const extendStimulusController = controller => {
       element.reflexData = data
 
       dispatchLifecycleEvent('before', element)
-
       adaptedConsumer.send(JSON.stringify({ channel }), data, stimulateOptions)
-      subscription.send(data)
 
       if (debugging) {
         Log.request(
@@ -346,6 +343,7 @@ if (!document.stimulusReflexInitialized) {
 export default {
   initialize,
   register,
+  getAbstractClass,
   setupDeclarativeReflexes,
   get debug () {
     return debugging

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -44,6 +44,7 @@ const createSubscription = controller => {
     adaptedConsumer.create_subscription(channel)
 
   controller.StimulusReflex.subscription = subscription
+  controller.StimulusReflex.consumer = adaptedConsumer
 }
 
 // Extends a regular Stimulus controller with StimulusReflex behavior.
@@ -54,11 +55,11 @@ const createSubscription = controller => {
 //
 const extendStimulusController = controller => {
   Object.assign(controller, {
-    // Indicates if the ActionCable web socket connection is open.
+    // Indicates if the consumer connection is open.
     // The connection must be open before calling stimulate.
     //
-    isActionCableConnectionOpen () {
-      return this.StimulusReflex.subscription.consumer.connection.isOpen()
+    isConsumerConnectionOpen() {
+      return this.StimulusReflex.consumer.isConnected()
     },
 
     // Invokes a server side reflex method.
@@ -99,8 +100,8 @@ const extendStimulusController = controller => {
 
       const { channel } = this.StimulusReflex
 
-      if (!this.isActionCableConnectionOpen())
-        throw 'The ActionCable connection is not open! `this.isActionCableConnectionOpen()` must return true before calling `this.stimulate()`'
+      if (!this.isConsumerConnectionOpen())
+        throw 'The consumer connection is not open! `this.isConsumerConnectionOpen()` must return true before calling `this.stimulate()`'
 
       // lifecycle setup
       element.reflexController = this
@@ -108,7 +109,7 @@ const extendStimulusController = controller => {
 
       dispatchLifecycleEvent('before', element)
 
-      adaptedConsumer.send(JSON.stringify({ channel }, data, stimulateOptions))
+      adaptedConsumer.send(JSON.stringify({ channel }), data, stimulateOptions)
       subscription.send(data)
 
       if (debugging) {


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)
An enhancement! 

## Description
This is a proposal to adapt the code to use an adapter for websockets. Which would give the user of the library a bit more flexibility, and it would make it easier to replace actioncable with something else. 

If this proposal is accepted, it would make it possible to split the javascript into `stimulus-reflex` which would be for rails alone and `stimulus-reflex-core` which is completely independent of actioncable. That in turn would make the bundle smaller for python users, as they would unnecessarily need to install actioncable as it is now. 

The adapter pattern would also allow for transport over http as I will explain in comments below. 

As a reference on how this affects django-sockpuppet -> https://github.com/jonathan-s/django-sockpuppet/pull/13

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
