### PR TITLE
Replace camelize with homegrown version

### DIFF
--- a/javascript/lifecycle.js
+++ b/javascript/lifecycle.js
@@ -1,4 +1,19 @@
-import { camelize } from 'inflected'
+const camelize = (value, uppercaseFirstLetter = true) => {
+  if (typeof value !== 'string') return ''
+  str = str
+    .replace(/[\s_](.)/g, $1 => {
+      return $1.toUpperCase()
+    })
+    .replace(/[\s_]/g, '')
+    .replace(/^(.)/, $1 => {
+      return $1.toLowerCase()
+    })
+
+  if (uppercaseFirstLetter) {
+    str = str.substr(0, 1).toUpperCase() + str.substr(1)
+  }
+  return str
+}
 
 // Invokes a lifecycle method on a StimulusReflex controller.
 //

--- a/javascript/lifecycle.js
+++ b/javascript/lifecycle.js
@@ -1,18 +1,14 @@
 const camelize = (value, uppercaseFirstLetter = true) => {
   if (typeof value !== 'string') return ''
-  str = str
-    .replace(/[\s_](.)/g, $1 => {
-      return $1.toUpperCase()
-    })
+  value = value
+    .replace(/[\s_](.)/g, $1 => $1.toUpperCase())
     .replace(/[\s_]/g, '')
-    .replace(/^(.)/, $1 => {
-      return $1.toLowerCase()
-    })
+    .replace(/^(.)/, $1 => $1.toLowerCase())
 
-  if (uppercaseFirstLetter) {
-    str = str.substr(0, 1).toUpperCase() + str.substr(1)
-  }
-  return str
+  if (uppercaseFirstLetter)
+    value = value.substr(0, 1).toUpperCase() + value.substr(1)
+
+  return value
 }
 
 // Invokes a lifecycle method on a StimulusReflex controller.

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -36,7 +36,6 @@
   "dependencies": {
     "@rails/actioncable": ">= 6.0",
     "cable_ready": ">= 4.1.2",
-    "inflected": ">= 2.0",
     "stimulus": ">= 1.1",
     "uuid": ">= 7.0.3"
   },

--- a/javascript/yarn.lock
+++ b/javascript/yarn.lock
@@ -2283,11 +2283,6 @@ indexes-of@^1.0.1:
   resolved "https://registry.yarnpkg.com/indexes-of/-/indexes-of-1.0.1.tgz#f30f716c8e2bd346c7b67d3df3915566a7c05607"
   integrity sha1-8w9xbI4r00bHtn0985FVZqfAVgc=
 
-"inflected@>= 2.0":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/inflected/-/inflected-2.0.4.tgz#323770961ccbe992a98ea930512e9a82d3d3ef77"
-  integrity sha512-HQPzFLTTUvwfeUH6RAGjD8cHS069mBqXG5n4qaxX7sJXBhVQrsGgF+0ZJGkSuN6a8pcUWB/GXStta11kKi/WvA==
-
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)
Enhancement. 
## Description
In the spirit of #181 I thought it would be a good idea to remove the dependency of inflected as well, as that will reduce the bundle with a few more bytes. 

Compare with how it's done at inflected -> https://github.com/martinandert/inflected/blob/master/src/camelize.js

and rails -> https://apidock.com/rails/String/camelize

## Why should this be added
Bundle size gets smaller and we rely and fewer dependencies. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
