### PR TITLE
Allow to call stimulate without a reflex target

### DIFF
--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -88,7 +88,7 @@ const extendStimulusController = controller => {
     stimulate () {
       const url = location.href
       const args = Array.from(arguments)
-      const target = args.shift()
+      const target = args.shift() || 'StimulusReflex::Reflex#default_reflex'
       const element =
         args[0] && args[0].nodeType === Node.ELEMENT_NODE
           ? args.shift()

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -96,4 +96,8 @@ class StimulusReflex::Reflex
   def halted?
     !!@halted
   end
+
+  def default_reflex
+    # noop default reflex to force page reloads
+  end
 end


### PR DESCRIPTION
# Enhancement

## Description

This PR allows to call the `stimulate()` method in a Stimulus Controller without to provide a reflex target.

### Setup

The basic setup looks like this:

```html
<div data-controller="example">
  <input type="text" data-action="keyup->example#example">
</div>
```

```javascript
// example_controller.js

import { Controller } from 'stimulus'
import StimulusReflex from 'stimulus_reflex'

export default class extends Controller {

  connect () {
    StimulusReflex.register(this)
  }

  example () {
    this.stimulate()
  }

}
```

It also works if you just specify an event in the `data-reflex` attribute on a html element without the need to call the `stimulate` method in a Stimulus Controller
```html
<input type="text" data-reflex="keyup">
```

Resolves #179

## Why should this be added

It makes it easier for any use case you just need to reload the page with a reflex. But with this you don't have to define an empty reflex on the server side to just reload the page. 

/cc @bbugh

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
