### PR TITLE
Add guard to morph that checks stimulusReflex

### DIFF
--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -298,8 +298,9 @@ if (!document.stimulusReflexInitialized) {
   // to the source element in case it gets removed from the DOM via morph.
   // This is safe because the server side reflex completed successfully.
   document.addEventListener('cable-ready:before-morph', event => {
-    const { selector } = event.detail || {}
-    const { reflexId, attrs, last } = event.detail.stimulusReflex || {}
+    const { selector, stimulusReflex } = event.detail || {}
+    if (!stimulusReflex) return
+    const { reflexId, attrs, last } = stimulusReflex
     const element = findElement(attrs)
     const promise = promises[reflexId]
 


### PR DESCRIPTION
# Bug fix

## Description

StimulusReflex was assuming that it owned all CableReady morph operations and would emit console error messages on unrelated morph broadcasts.

This PR adds a guard that verifies that SR only handles SR morphs.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing