### PR TITLE
Fix undefined is not an object for Object.keys in log.js

### DIFF
--- a/javascript/log.js
+++ b/javascript/log.js
@@ -23,11 +23,13 @@ function success (response) {
   const { event, events } = response
   const { reflexId, target, last } = event.detail.stimulusReflex || {}
 
-  Object.keys(events).map(selector => {
-    elements[selector] = events[selector].detail.element
-    html[selector] = events[selector].detail.html
-    payloads[selector] = events[selector].detail.stimulusReflex
-  })
+  if (events) {
+    Object.keys(events).map(selector => {
+      elements[selector] = events[selector].detail.element
+      html[selector] = events[selector].detail.html
+      payloads[selector] = events[selector].detail.stimulusReflex
+    })
+  }
 
   console.log(`\u2B05 ${target}`, {
     reflexId,


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bug fix

## Description

There are somehow some cases where `response.events` is not defined. This PR adds an extra check to prevent the JavaScript errors you would get in the web developer console. 

<img width="856" alt="Screenshot 2020-05-17 at 03 37 51" src="https://user-images.githubusercontent.com/6411752/82164130-5e7a6600-98af-11ea-896c-aeb26850a52b.png">

## Why should this be added

Less JavaScript errors in the console are always better 😉 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
