### PR TITLE
Map hashes in incoming arguments using with_indifferent_access

### DIFF
--- a/lib/stimulus_reflex/channel.rb
+++ b/lib/stimulus_reflex/channel.rb
@@ -23,6 +23,7 @@ class StimulusReflex::Channel < ActionCable::Channel::Base
     reflex_name, method_name = target.split("#")
     reflex_name = reflex_name.classify
     arguments = data["args"] || []
+    arguments.map! { |argument| map_hashes_in(argument) }
     element = StimulusReflex::Element.new(data["attrs"])
 
     begin
@@ -50,6 +51,13 @@ class StimulusReflex::Channel < ActionCable::Channel::Base
   end
 
   private
+
+  def map_hashes_in(argument)
+    return argument.with_indifferent_access if argument.is_a?(Hash)
+
+    argument.map! { |nested_argument| map_hashes_in(nested_argument) } if argument.is_a?(Array)
+    argument
+  end
 
   def is_reflex?(reflex_class)
     reflex_class.ancestors.include? StimulusReflex::Reflex


### PR DESCRIPTION
# Enhancement

## Description

I've always been a stickler for wanting to use symbol keys in hashes and have usually been spoiled with Rails providing them. So when I noticed that hashes (or arrays containing hashes, etc.) coming into a reflex argument only provided string keys (right out of the JSON parser I'm guessing), I knew I needed to do something about that. 😄

If this is a potential performance concern, maybe we could put the map function behind a configuration option. Default true would be preferable!

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
