### PR TITLE
Form parameters

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@rails/actioncable": ">= 6.0",
     "cable_ready": ">= 4.1.2",
-    "form-serialize": "^0.7.2",
+    "form-serialize": ">= 0.7.2",
     "stimulus": ">= 1.1"
   },
   "devDependencies": {

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@rails/actioncable": ">= 6.0",
     "cable_ready": ">= 4.1.2",
+    "form-serialize": "^0.7.2",
     "stimulus": ">= 1.1"
   },
   "devDependencies": {

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -103,7 +103,10 @@ const extendStimulusController = controller => {
         permanent_attribute_name:
           stimulusApplication.schema.reflexPermanentAttribute,
         reflexId: reflexId,
-        params: serializeForm(element.closest("form"), { hash: true, empty: true })
+        params: serializeForm(element.closest('form'), {
+          hash: true,
+          empty: true
+        })
       }
       const { subscription } = this.StimulusReflex
       const { connection } = subscription.consumer

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -1,5 +1,6 @@
 import { Controller } from 'stimulus'
 import CableReady from 'cable_ready'
+import serializeForm from 'form-serialize'
 import { defaultSchema } from './schema'
 import { getConsumer } from './consumer'
 import { dispatchLifecycleEvent } from './lifecycle'
@@ -101,7 +102,8 @@ const extendStimulusController = controller => {
         selectors,
         permanent_attribute_name:
           stimulusApplication.schema.reflexPermanentAttribute,
-        reflexId: reflexId
+        reflexId: reflexId,
+        params: serializeForm(element.closest("form"), { hash: true, empty: true })
       }
       const { subscription } = this.StimulusReflex
       const { connection } = subscription.consumer

--- a/javascript/yarn.lock
+++ b/javascript/yarn.lock
@@ -2006,6 +2006,11 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
+form-serialize@^0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/form-serialize/-/form-serialize-0.7.2.tgz#b0a2ff0c22026fb6d3d15c9d33f6de6a432e4732"
+  integrity sha1-sKL/DCICb7bT0VydM/beakMuRzI=
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"

--- a/lib/generators/templates/custom_reflex.rb
+++ b/lib/generators/templates/custom_reflex.rb
@@ -11,6 +11,7 @@ class <%= class_name %>Reflex < ApplicationReflex
   #   - session - the ActionDispatch::Session store for the current visitor
   #   - url - the URL of the page that triggered the reflex
   #   - element - a Hash like object that represents the HTML element that triggered the reflex
+  #   - params - parameters from the element's closest form (if any)
   #
   # Example:
   #

--- a/lib/stimulus_reflex/channel.rb
+++ b/lib/stimulus_reflex/channel.rb
@@ -24,11 +24,12 @@ class StimulusReflex::Channel < ActionCable::Channel::Base
     reflex_name = reflex_name.classify
     arguments = data["args"] || []
     element = StimulusReflex::Element.new(data["attrs"])
+    params = data["params"] || {}
 
     begin
       reflex_class = reflex_name.constantize
       raise ArgumentError.new("#{reflex_name} is not a StimulusReflex::Reflex") unless is_reflex?(reflex_class)
-      reflex = reflex_class.new(self, url: url, element: element, selectors: selectors, method_name: method_name)
+      reflex = reflex_class.new(self, url: url, element: element, selectors: selectors, method_name: method_name, params: params)
       delegate_call_to_reflex reflex, method_name, arguments
     rescue => invoke_error
       reflex.rescue_with_handler(invoke_error)

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -78,7 +78,7 @@ class StimulusReflex::Reflex
       )
       path_params = Rails.application.routes.recognize_path_with_request(req, url, req.env[:extras] || {})
       req.env.merge(ActionDispatch::Http::Parameters::PARAMETERS_KEY => path_params)
-      req.env.merge!("action_dispatch.request.parameters" => @params)
+      req.env["action_dispatch.request.parameters"] = @params
       req.tap { |r| r.session.send :load! }
     end
   end

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class StimulusReflex::Reflex
+  include ActionController::StrongParameters
   include ActiveSupport::Rescuable
   include ActiveSupport::Callbacks
 
@@ -42,7 +43,7 @@ class StimulusReflex::Reflex
     end
   end
 
-  attr_reader :channel, :url, :element, :selectors, :method_name, :params
+  attr_reader :channel, :url, :element, :selectors, :method_name
 
   delegate :connection, to: :channel
   delegate :session, to: :request
@@ -53,7 +54,7 @@ class StimulusReflex::Reflex
     @element = element
     @selectors = selectors
     @method_name = method_name
-    @params = ActionController::Parameters.new(params)
+    @params = params
   end
 
   def request
@@ -77,6 +78,7 @@ class StimulusReflex::Reflex
       )
       path_params = Rails.application.routes.recognize_path_with_request(req, url, req.env[:extras] || {})
       req.env.merge(ActionDispatch::Http::Parameters::PARAMETERS_KEY => path_params)
+      req.env.merge!("action_dispatch.request.parameters" => @params)
       req.tap { |r| r.session.send :load! }
     end
   end

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -42,17 +42,18 @@ class StimulusReflex::Reflex
     end
   end
 
-  attr_reader :channel, :url, :element, :selectors, :method_name
+  attr_reader :channel, :url, :element, :selectors, :method_name, :params
 
   delegate :connection, to: :channel
   delegate :session, to: :request
 
-  def initialize(channel, url: nil, element: nil, selectors: [], method_name: nil)
+  def initialize(channel, url: nil, element: nil, selectors: [], method_name: nil, params: {})
     @channel = channel
     @url = url
     @element = element
     @selectors = selectors
     @method_name = method_name
+    @params = ActionController::Parameters.new(params)
   end
 
   def request

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class StimulusReflex::Reflex
-  include ActionController::StrongParameters
   include ActiveSupport::Rescuable
   include ActiveSupport::Callbacks
 
@@ -105,5 +104,9 @@ class StimulusReflex::Reflex
 
   def default_reflex
     # noop default reflex to force page reloads
+  end
+
+  def params
+    @_params ||= ActionController::Parameters.new(request.parameters)
   end
 end


### PR DESCRIPTION
# Enhancement

## Description

After discussion with @hopsoft I have a PR for (potentially) introducing `params` to StimulusReflex.

This code:
* Sends `params` to StimulusReflex from JavaScript
  * Adds the [`form-serialize`](https://www.npmjs.com/package/form-serialize) package from NPM which has 0 dependencies and is less than ~300kb~ [1kb](https://bundlephobia.com/result?p=form-serialize@0.7.2) This allows us to serialize a form (including nested parameters) into a hash with one line.
* Casts and exposes `params` to `StimulusReflex::Reflex` as a `ActionController::Parameters` instance

Here's what a reflex can do with the new params:

```ruby
class Post < ApplicationRecord
  validates :name, presence: true
  has_many :categories
  accepts_nested_attributes_for :categories
end

class Category < ApplicationRecord
  validates :name, presence: true
  belongs_to :post
end
```

```ruby
class PostsController < ApplicationController
  def edit
    # Memoizing means the instance set in the reflex (from params) will be reused
    # when the page re-renders from SR, this is an important part of the magic.
    @post ||= Post.find(params[:id])
  end
end
```

```erb
<%= form_with model: @post, data: { reflex: "submit->PostReflex#submit", signed_id: @post.to_sgid.to_s } do |form| %>
  <% if @post.errors.any? %>
    <!-- keep in mind, if you have error CSS classes defined, they will automatically pick up, too -->
    <% @post.errors.full_messages.each do |message| %>
      <li><%= message %>
    <% end %>
  <% end %>
  <div>
    <%= f.label :name %>
    <!-- changing this field will trigger the autosave
            if the field is changed while you have invalid categories, 
            they will stick around on re-render, but will show validation errors 
            because of accepts_nested_attributes and the category validations --> 
    <%= f.text_field :name, data: { reflex: "change->PostReflex#submit" } %>
  </div>
  <%= form.fields_for :categories, @post.categories do |category_form| %>
    <%= category_form.hidden :id %>
    <%= category_form.label :name,  %>
    <!-- changing this doesnt autosave, it's the responibility of either the submit button
            or the autosave that happens on name above.
            this is a bit silly of an example I've made, but it's to show how both autosaving
            and regular "form submission" can work together. -->
    <%= category_form.text_field :name
  <% end %>
  <%= link_to "New category", "#", data: { reflex: "click->PostReflex#build_category" } %>
  <%= form.submit %>
<% end %>
```

```ruby
class PostReflex < ApplicationReflex
  before_reflex do
    @post = GlobalID::Locator.locate_signed(element.dataset.dig("signed-id")
    @post.assign_attributes(post_params)
  end

  def submit
    @post.save
  end

  # Triggers re-render with new category.
  # Since we're building the object from params in the callback above, we can
  # click this as many times as we want to keep getting new categories.
  def build_category
    @post.categories.build
  end

  private

  def post_params
    params.require(:post).permit(:name, categories_attributes: [:id, :name])
  end
end
```

Fixes #199 

## Why should this be added

This has allowed us, at Podia, to take an edit form that requires auto-saving a model that `has_many` nested attributes and make it interactive with only **8 lines** of JavaScript.

We treat this form like a plain old Rails form (PORF™) by building our form like it's server-rendered, but stimulating it with StimulusReflex.

Adding params to the Reflex allows us to work with forms in StimulusReflex as first-class citizens, and feel (not quite 100%) like working with a standard server-rendered Rails form.

The benefits we've seen so far:
* Autosaving is as simple as adding `data: { reflex: "change->Reflex#update" }` to each field that should autosave (since the field is inside the `<form>` all the params are automatically serialized and send to StimulusReflex)
  * For any "JavaScript sprinkles" we need, we can utilize lifecycle methods in Stimulus
* Because we've defined our error styling, we get form errors for free
  * We instantiate an object from params, if it fails to save that object is still assigned to the instance variable and when the page re-renders errors are just there
* We have access to `params` in callbacks (`before_reflex`, `after_reflex`) that allow us to make decisions/instantiate objects from params
* Params are as accessible from the Reflex as from a controller
  * `params.require(:post).permit(:name, categories_attributes: [:id, :_destroy, :name])`
* Building a new record for a nested `has_many` association requires no JavaScript
  * Let me say that again, **no JavaScript** 😱
  * We just call a reflex that builds the new record: `@post.categories.build`
  * Because we have a Rails form that knows about `fields_for :categories, @post.categories` the re-render populates the empty form field
  * BUT THAT'S NOT ALL! Because we have access to `params`, and we instantiate an object from `params` each time we don't lose the built record if saving the record fails, it re-renders just like it would if a controller action went to update/save the record and had to bail out with error messages

It packs a lot of punch for us, with a "minimal" amount of code (in terms of implementation as well as code added to StimulusReflex)

I've been through several iterations of this, and after pairing with @hopsoft today, this is the proposal we've come up with.

I'm glad to answer any questions/hear feedback!

❤️ 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
