### PR TITLE
Loosen Rails requirement to 5.2 with instructions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       cable_ready (>= 4.1.2)
       nokogiri
       rack
-      rails (>= 6.0)
+      rails (>= 5.2)
 
 GEM
   remote: https://rubygems.org/

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -5,7 +5,7 @@ description: How to prepare your app to use StimulusReflex
 # Setup
 
 {% hint style="warning" %}
-StimulusReflex v3 has been released, and there are some big changes. **Rails 6+ and server-side session storage are now required.**
+StimulusReflex v3 has been released, and there are some big changes. **Server-side session storage is now required.**
 
 You can find additional information for supporting Rails 5.2+ below.
 {% endhint %}
@@ -117,16 +117,16 @@ StimulusReflex supports both client and server logging of Reflexes.
 
 ## Rails 5.2+ Support
 
-When the Rails core team renamed the ActionCable JS npm package from `actioncable` to `@rails/actioncable` it made it very difficult to reliably import ActionCable. After evaluating our options, we made the difficult decision of updating to the new package name and freezing _official_ Rails 5.2 support on the 2.2.x branch of StimulusReflex.
+To use Rails 5.2 with StimulusReflex, you'll need the latest Action Cable package from npm: `@rails/actioncable`
 
-```ruby
-bundle add stimulus_reflex --version "~> 2.2.3"
-yarn add stimulus_reflex@2.2.3
-```
-
-While we don't have the resources to maintain two distinct package versions, we're proud of 2.2.x and consider it stable. In the unfortunate case of a critical security issue, we will make every attempt to backport hotfixes.
+1. Replace `actioncable` with `@rails/actioncable` in `package.json`
+  * `yarn remove actioncable`
+  * `yarn add @rails/actioncable`
+2. Replace any instance of `import Actioncable from "actioncable"` with `import { createConsumer } from "@rails/actioncable"`
+  * This imports the `createConsumer` function directly
+  * Previously, you might call `createConsumer()` on the `Actioncable` import: `Actioncable.createConsumer()`
+  * Now, you can reference `createConsumer()` directly
 
 {% hint style="info" %}
 There's nothing about StimulusReflex 3+ that shouldn't work fine in a Rails 5.2 app if you're willing to do a bit of manual package dependency management.
 {% endhint %}
-

--- a/stimulus_reflex.gemspec
+++ b/stimulus_reflex.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "rack"
   gem.add_dependency "nokogiri"
-  gem.add_dependency "rails", ">= 6.0"
+  gem.add_dependency "rails", ">= 5.2"
   gem.add_dependency "cable_ready", ">= 4.1.2"
 
   gem.add_development_dependency "bundler", "~> 2.0"


### PR DESCRIPTION
# Um... Enhancement? Maybe?

## Description

We're dinosaurs at Podia running on Rails 5.2. 👀 Nate helped us "shove" StimulusReflex into our application. Except, there was no shoving involved. We only had to loosen the requirement on Rails down to 5.2 and use the new `@rails/actioncable` npm package, instead of `actioncable`.

This PR loosens the requirement and adds instructions in the docs on how to upgrade your ActionCable JavaScript code, based on our experience.

## Why should this be added

I believe allowing Rails 5.2 apps into ReflexLand could help adoption from companies like ours. We're working hard on our Rails 6 upgrade, but we're not there yet.

Without this, we have to run a fork of StimulusReflex- which means:
* Pointing bundler to our GH repo for StimulusReflex
* Hosting another repo just for the JavaScript that we can point yarn to
  * The `javascript` folder is nested and I can't get yarn to point to a nested folder in a git repo 😅 

## Help!

I'm not 100% sure that our positive experience will translate to others running Rails 5.2. Do you see any reason why this _wouldn't_ work in a Rails 5.2 app?

## Checklist

- [X] My code follows the style guidelines of this project
- [X] Checks (StandardRB & Prettier-Standard) are passing
