### PR TITLE
Stimulus reflexData assignment after callback 

### DIFF
--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -102,7 +102,7 @@ const extendStimulusController = controller => {
         selectors,
         permanent_attribute_name:
           stimulusApplication.schema.reflexPermanentAttribute,
-        reflexId: reflexId,
+        reflexId: reflexId
       }
       const { subscription } = this.StimulusReflex
       const { connection } = subscription.consumer

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -94,20 +94,7 @@ const extendStimulusController = controller => {
       const attrs = extractElementAttributes(element)
       const selectors = getReflexRoots(element)
       const reflexId = uuidv4()
-      const data = {
-        target,
-        args,
-        url,
-        attrs,
-        selectors,
-        permanent_attribute_name:
-          stimulusApplication.schema.reflexPermanentAttribute,
-        reflexId: reflexId,
-        params: serializeForm(element.closest('form'), {
-          hash: true,
-          empty: true
-        })
-      }
+      const data = { target }
       const { subscription } = this.StimulusReflex
       const { connection } = subscription.consumer
 
@@ -120,7 +107,24 @@ const extendStimulusController = controller => {
 
       dispatchLifecycleEvent('before', element)
 
-      subscription.send(data)
+      setTimeout(() => {
+        element.reflexData = {
+          ...data,
+          args,
+          url,
+          attrs,
+          selectors,
+          permanent_attribute_name:
+            stimulusApplication.schema.reflexPermanentAttribute,
+          reflexId: reflexId,
+          params: serializeForm(element.closest('form'), {
+            hash: true,
+            empty: true
+          })
+        }
+
+        subscription.send(element.reflexData)
+      })
 
       if (debugging) {
         Log.request(

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -94,7 +94,16 @@ const extendStimulusController = controller => {
       const attrs = extractElementAttributes(element)
       const selectors = getReflexRoots(element)
       const reflexId = uuidv4()
-      const data = { target }
+      const data = {
+        target,
+        args,
+        url,
+        attrs,
+        selectors,
+        permanent_attribute_name:
+          stimulusApplication.schema.reflexPermanentAttribute,
+        reflexId: reflexId,
+      }
       const { subscription } = this.StimulusReflex
       const { connection } = subscription.consumer
 
@@ -108,19 +117,16 @@ const extendStimulusController = controller => {
       dispatchLifecycleEvent('before', element)
 
       setTimeout(() => {
+        const { params } = element.reflexData || {}
         element.reflexData = {
           ...data,
-          args,
-          url,
-          attrs,
-          selectors,
-          permanent_attribute_name:
-            stimulusApplication.schema.reflexPermanentAttribute,
-          reflexId: reflexId,
-          params: serializeForm(element.closest('form'), {
-            hash: true,
-            empty: true
-          })
+          params: {
+            ...params,
+            ...serializeForm(element.closest('form'), {
+              hash: true,
+              empty: true
+            })
+          }
         }
 
         subscription.send(element.reflexData)


### PR DESCRIPTION
# Bug fix

## Description

Changing an element in a `beforeReflexMethod` lifecycle method (in Stimulus) doesn't reflect the element's change when sent to Rails.

When I went to change an element in a callback, the element change wasn't reflected Rails-side. In the specific instance that exposed this, I was changing the value of `_destroy` on a nested field from `0` to `1` so it will delete.

## Why should this be added

With the addition of params, modifying an element in the DOM during a callback (like our example deleting a nested field) would be highly beneficial, I believe. I would anticipate there are other use-cases where you'd want to make a change to an element before it's sent to Rails, though I don't have any good examples off the top of my head.

## Notes

@hopsoft paired with me on this and can explain better the changes made here if necessary.

We wrapped `subscription.send` in a `setTimeout` due to something (I can't explain) related to the lifecycle method firing _after_ the reflex is sent to Rails.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
