### PR TITLE
Make element even more user friendly

### DIFF
--- a/lib/stimulus_reflex/element.rb
+++ b/lib/stimulus_reflex/element.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 
 class StimulusReflex::Element < OpenStruct
-  attr_reader :attributes, :dataset
+  attr_reader :attributes, :data_attributes
 
   def initialize(attrs = {})
     @attributes = HashWithIndifferentAccess.new(attrs || {})
-    data_attributes = @attributes.select { |key, _| key.start_with? "data-" }
-    data_attributes.transform_keys! { |key| key.delete_prefix("data-") }
-    @dataset = OpenStruct.new(data_attributes.merge(data_attributes.transform_keys(&:underscore)))
-    @dataset.freeze
-    super @attributes.merge(@attributes.transform_keys(&:underscore))
-    freeze
+    @data_attributes = attributes.each_with_object(HashWithIndifferentAccess.new) { |(key, value), memo|
+      memo[key.delete_prefix("data-")] = value if key.start_with?("data-")
+    }
+    super attributes.merge(attributes.transform_keys(&:underscore))
+  end
+
+  def dataset
+    @dataset ||= OpenStruct.new(data_attributes.merge(data_attributes.transform_keys(&:underscore)))
   end
 end

--- a/lib/stimulus_reflex/element.rb
+++ b/lib/stimulus_reflex/element.rb
@@ -6,8 +6,10 @@ class StimulusReflex::Element < OpenStruct
   def initialize(attrs = {})
     @attributes = HashWithIndifferentAccess.new(attrs || {})
     data_attributes = @attributes.select { |key, _| key.start_with? "data-" }
-    data_attributes.transform_keys! { |key| key.delete_prefix("data-").underscore }
-    @dataset = OpenStruct.new(data_attributes.freeze)
-    super @attributes.merge(@attributes.transform_keys(&:underscore)).freeze
+    data_attributes.transform_keys! { |key| key.delete_prefix("data-") }
+    @dataset = OpenStruct.new(data_attributes.merge(data_attributes.transform_keys(&:underscore)))
+    @dataset.freeze
+    super @attributes.merge(@attributes.transform_keys(&:underscore))
+    freeze
   end
 end

--- a/lib/stimulus_reflex/element.rb
+++ b/lib/stimulus_reflex/element.rb
@@ -1,18 +1,13 @@
 # frozen_string_literal: true
 
-class StimulusReflex::Element
-  attr_reader :attributes
-
-  delegate :[], to: :"@attributes"
+class StimulusReflex::Element < OpenStruct
+  attr_reader :attributes, :dataset
 
   def initialize(attrs = {})
-    @attributes = HashWithIndifferentAccess.new(attrs || {}).freeze
-  end
-
-  def dataset
-    @dataset ||= attributes.each_with_object(HashWithIndifferentAccess.new) { |(key, value), memo|
-      next unless key.start_with?("data-")
-      memo[key.delete_prefix("data-")] = value
-    }.freeze
+    @attributes = HashWithIndifferentAccess.new(attrs || {})
+    data_attributes = @attributes.select { |key, _| key.start_with? "data-" }
+    data_attributes.transform_keys! { |key| key.delete_prefix("data-").underscore }
+    @dataset = OpenStruct.new(data_attributes.freeze)
+    super @attributes.merge(@attributes.transform_keys(&:underscore)).freeze
   end
 end


### PR DESCRIPTION
# Enhancement

## Description

Update `StimulusReflex::Element` to inherit from `OpenStruct` and expose attribtes via dot notation. Also, exposes `dataset` as an `OpenStruct` with the same behavior.

### Example

```html
<input id="name" type="text" value="hopsoft" 
  data-reflex="click->ExampleReflex#do_stuff" data-foo="bar">
```

```ruby
class ExampleReflex < ApplicationReflex
  def do_stuff
    element.id    # => name
    element[:id]  # => name
    element["id"] # => name

    element.value # => hopsoft

    element.dataset.foo    # => bar
    element.dataset[:foo]  # => bar
    element.dataset["foo"] # => bar
  end
end
```

## Why should this be added

Makes working with the element representation in the reflex even better.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing