### PR TITLE
reflex_name restriction loosening

### DIFF
--- a/lib/stimulus_reflex/channel.rb
+++ b/lib/stimulus_reflex/channel.rb
@@ -54,7 +54,7 @@ class StimulusReflex::Channel < ActionCable::Channel::Base
   private
 
   def compute_reflex_name(reflex_name)
-    return "#{reflex_name}Reflex" unless is_reflex?(reflex_name.constantize)
+    raise unless is_reflex?(reflex_name.constantize)
     reflex_name
   rescue
     "#{reflex_name}Reflex"

--- a/lib/stimulus_reflex/channel.rb
+++ b/lib/stimulus_reflex/channel.rb
@@ -57,7 +57,7 @@ class StimulusReflex::Channel < ActionCable::Channel::Base
     begin
       return "#{reflex_name}Reflex" unless is_reflex?(reflex_name.constantize)
       reflex_name
-    rescue => e
+    rescue
       "#{reflex_name}Reflex"
     end
   end

--- a/lib/stimulus_reflex/channel.rb
+++ b/lib/stimulus_reflex/channel.rb
@@ -54,12 +54,10 @@ class StimulusReflex::Channel < ActionCable::Channel::Base
   private
 
   def compute_reflex_name(reflex_name)
-    begin
-      return "#{reflex_name}Reflex" unless is_reflex?(reflex_name.constantize)
-      reflex_name
-    rescue
-      "#{reflex_name}Reflex"
-    end
+    return "#{reflex_name}Reflex" unless is_reflex?(reflex_name.constantize)
+    reflex_name
+  rescue
+    "#{reflex_name}Reflex"
   end
 
   def is_reflex?(reflex_class)

--- a/lib/stimulus_reflex/channel.rb
+++ b/lib/stimulus_reflex/channel.rb
@@ -55,8 +55,8 @@ class StimulusReflex::Channel < ActionCable::Channel::Base
 
   def compute_reflex_name(reflex_name)
     begin
-      is_reflex?(reflex_name.constantize)
-      return reflex_name
+      return "#{reflex_name}Reflex" unless is_reflex?(reflex_name.constantize)
+      reflex_name
     rescue => e
       "#{reflex_name}Reflex"
     end

--- a/lib/stimulus_reflex/channel.rb
+++ b/lib/stimulus_reflex/channel.rb
@@ -55,7 +55,7 @@ class StimulusReflex::Channel < ActionCable::Channel::Base
 
   def compute_reflex_name(reflex_name)
     begin
-      reflex_name.constantize
+      is_reflex?(reflex_name.constantize)
       return reflex_name
     rescue => e
       "#{reflex_name}Reflex"

--- a/lib/stimulus_reflex/channel.rb
+++ b/lib/stimulus_reflex/channel.rb
@@ -22,14 +22,13 @@ class StimulusReflex::Channel < ActionCable::Channel::Base
     target = data["target"].to_s
     reflex_name, method_name = target.split("#")
     reflex_name = reflex_name.classify
-    reflex_name = reflex_name.end_with?("Reflex") ? reflex_name : compute_reflex_name(reflex_name)
+    reflex_name = reflex_name.end_with?("Reflex") ? reflex_name : "#{reflex_name}Reflex"
     arguments = data["args"] || []
     element = StimulusReflex::Element.new(data["attrs"])
     params = data["params"] || {}
 
     begin
-      reflex_class = reflex_name.constantize
-      raise ArgumentError.new("#{reflex_name} is not a StimulusReflex::Reflex") unless is_reflex?(reflex_class)
+      reflex_class = reflex_name.constantize.tap { |klass| raise ArgumentError.new("#{reflex_name} is not a StimulusReflex::Reflex") unless is_reflex?(klass) }
       reflex = reflex_class.new(self, url: url, element: element, selectors: selectors, method_name: method_name, params: params)
       delegate_call_to_reflex reflex, method_name, arguments
     rescue => invoke_error
@@ -52,13 +51,6 @@ class StimulusReflex::Channel < ActionCable::Channel::Base
   end
 
   private
-
-  def compute_reflex_name(reflex_name)
-    raise unless is_reflex?(reflex_name.constantize)
-    reflex_name
-  rescue
-    "#{reflex_name}Reflex"
-  end
 
   def is_reflex?(reflex_class)
     reflex_class.ancestors.include? StimulusReflex::Reflex

--- a/lib/stimulus_reflex/channel.rb
+++ b/lib/stimulus_reflex/channel.rb
@@ -22,6 +22,7 @@ class StimulusReflex::Channel < ActionCable::Channel::Base
     target = data["target"].to_s
     reflex_name, method_name = target.split("#")
     reflex_name = reflex_name.classify
+    reflex_name = reflex_name.end_with?("Reflex") ? reflex_name : compute_reflex_name(reflex_name)
     arguments = data["args"] || []
     element = StimulusReflex::Element.new(data["attrs"])
     params = data["params"] || {}
@@ -51,6 +52,15 @@ class StimulusReflex::Channel < ActionCable::Channel::Base
   end
 
   private
+
+  def compute_reflex_name(reflex_name)
+    begin
+      reflex_name.constantize
+      return reflex_name
+    rescue => e
+      "#{reflex_name}Reflex"
+    end
+  end
 
   def is_reflex?(reflex_class)
     reflex_class.ancestors.include? StimulusReflex::Reflex


### PR DESCRIPTION
## Type of PR (feature, enhancement, bug fix, etc.)

# Enhancement

## Description

This PR would make the string fragment "Reflex" used in the `data-reflex` attributes optional, allowing for a shorter syntax.

It also allows for the use of Reflex classes that do not end in Reflex, while not changing the existing default behavior.

### Examples

This is the current behavior:

```html
<button data-reflex="click->PowerReflex#lift">Lift</button>
```
This calls PowerReflex#lift.

```html
<button data-reflex="click->Power#lift">Lift</button>
```
This first checks to see if there is a Power class, and if there is, that it implements `StimulusReflex::Reflex`. If everything looks good, Power is your Reflex class.

If there is no Power class, or Power does not inherit from `StimulusReflex::Reflex`, it falls back to PowerReflex as your class. This is transparent to the client.

## Why should this be added

First, I should say that I'm not emotionally attached to this outcome, and I'm not in love with my implementation - although I'm glad it's 100% server-side. Unfortunately, Ruby's `defined?` method handles `User` and `"User".constantize` differently:

```ruby
x = User
defined? User # true
defined? "User".constantize # "method"
defined? x # "local-variable"
```
I'm sure there are more experienced Rubyists who know how to make this better, but I didn't want to require therapy to get this done, so I went with an admittedly hacky begin..rescue approach, instead.

Anyhow, here are the FOR arguments:

- shorter syntax
- not restricted to classes ending in "Reflex"
- backwards compatible

## Heads up

I found a bug: line 31 of `channel.rb` (on current master branch; it's 32 in this PR) raises an ArgumentError if the reflex_class does not inherit from `StimulusReflex::Reflex`. However, line 35/36 - the first line of the error rescue, calls `reflex.rescue_with_handler()`. Unfortunately, if reflex_class is *not* a Reflex, it will be **nil**, causing this rescue mission to fail.

In other words, on today's master branch, if we have a power_reflex.rb that forgets to inherit, it will throw this ugly error instead of a nice friendly error.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
