### PR TITLE
Proposal: data-reflex-debounce

### DIFF
--- a/javascript/schema.js
+++ b/javascript/schema.js
@@ -1,5 +1,6 @@
 export const defaultSchema = {
   reflexAttribute: 'data-reflex',
   reflexPermanentAttribute: 'data-reflex-permanent',
-  reflexRootAttribute: 'data-reflex-root'
+  reflexRootAttribute: 'data-reflex-root',
+  reflexDebounceAttribute: 'data-reflex-debounce'
 }

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -26,6 +26,10 @@ let actionCableConsumer
 //
 const promises = {}
 
+// A dictionary to store debounces
+//
+const debounces = {}
+
 // Indicates if we should log calls to stimulate, etc...
 //
 let debugging = false
@@ -128,7 +132,17 @@ const extendStimulusController = controller => {
           }
         }
 
-        subscription.send(element.reflexData)
+        const debounceAttribute =
+          element.attributes[stimulusApplication.schema.reflexDebounceAttribute]
+        const debounceValue =
+          (debounceAttribute && debounceAttribute.value) || 0
+
+        clearTimeout(debounces[element])
+
+        debounces[element] = setTimeout(function () {
+          delete debounces[element]
+          subscription.send(element.reflexData)
+        }, debounceValue)
       })
 
       if (debugging) {


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Feature

## Description

First of all, I know it's yet another data-attribute 😉  ...and there are also ways to do this in JavaScript/Stimulus with something like the `debounce` function from `lodash-es`.

But nevertheless, it might be interesting to support something like this out of the box in StimulusReflex itself. 

But just to be honest: I'm not emotionally attached to this feature at all

## Why should this be added

This feature would make it easier to integrate a `debounce` into the StimulusReflex workflow and would allow to setup a debounce without the need of a Stimulus controller. 

### Example

This example would setup a debounce for the `<input>` element and would only fire after the given 500ms.

```html
<input data-reflex="keyup->ExampleReflex#search" data-reflex-debounce="500" />
```

I'm curious what you think about supporting something like this out of the box or if we should stick to our beloved Stimulus controllers ☺️ 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
