### PR TITLE
Fix calling wrong controller lifecycle methods

### DIFF
--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -14,6 +14,7 @@ import {
   extractElementDataset,
   findElement
 } from './attributes'
+import { extractReflexName } from './utils'
 
 // A reference to the Stimulus application registered with: StimulusReflex.initialize
 //
@@ -220,7 +221,10 @@ const setupDeclarativeReflexes = debounce(() => {
         element.getAttribute(stimulusApplication.schema.actionAttribute)
       )
       reflexes.forEach(reflex => {
-        const controller = allReflexControllers(stimulusApplication, element)[0]
+        const controller = findControllerByReflexString(
+          reflex,
+          allReflexControllers(stimulusApplication, element)
+        )
         let action
         if (controller) {
           action = `${reflex.split('->')[0]}->${
@@ -250,6 +254,21 @@ const setupDeclarativeReflexes = debounce(() => {
         )
     })
 }, 20)
+
+// Given a reflex string such as 'click->TestReflex#create' and a list of
+// controllers. It will find the matching controller based on the controller's
+// identifier. e.g. Given these controller identifiers ['foo', 'bar', 'test'],
+// it would select the 'test' controller.
+const findControllerByReflexString = (reflexString, controllers) => {
+  return controllers.find(controller => {
+    if (!controller.identifier) return
+
+    return (
+      extractReflexName(reflexString).toLowerCase() ===
+      controller.identifier.toLowerCase()
+    )
+  })
+}
 
 // compute the DOM element(s) which will be the morph root
 // use the data-reflex-root attribute on the reflex or the controller

--- a/javascript/test/utils.extractReflexName.test.js
+++ b/javascript/test/utils.extractReflexName.test.js
@@ -2,21 +2,31 @@ import assert from 'assert'
 import { extractReflexName } from '../utils'
 
 describe('extractReflexName', () => {
-  describe('when it includes an event name', () => {
-    it('returns a reflex name', () => {
-      assert(extractReflexName('click->TestReflex#create') === 'Test')
+  describe("when it includes 'Reflex'", () => {
+    describe('when it includes an event name', () => {
+      it('returns a reflex name', () => {
+        assert(extractReflexName('click->TestReflex#create') === 'Test')
+      })
     })
-  })
 
-  describe('when it does not include an event name', () => {
-    it('returns a reflex name', () => {
-      assert(extractReflexName('TestReflex#create') === 'Test')
+    describe('when it does not include an event name', () => {
+      it('returns a reflex name', () => {
+        assert(extractReflexName('TestReflex#create') === 'Test')
+      })
     })
   })
 
   describe("when it does not include 'Reflex'", () => {
-    it('returns a reflex name', () => {
-      assert(extractReflexName('Test#create') === 'Test')
+    describe('when it includes an event name', () => {
+      it('returns a reflex name', () => {
+        assert(extractReflexName('click->Test#create') === 'Test')
+      })
+    })
+
+    describe('when it does not include an event name', () => {
+      it('returns a reflex name', () => {
+        assert(extractReflexName('Test#create') === 'Test')
+      })
     })
   })
 

--- a/javascript/test/utils.extractReflexName.test.js
+++ b/javascript/test/utils.extractReflexName.test.js
@@ -1,0 +1,22 @@
+import assert from 'assert'
+import { extractReflexName } from '../utils'
+
+describe('extractReflexName', () => {
+  describe('when it includes an event name', () => {
+    it('returns a reflex name', () => {
+      assert(extractReflexName('click->TestReflex#create') === 'Test')
+    })
+  })
+
+  describe('when it does not include an event name', () => {
+    it('returns a reflex name', () => {
+      assert(extractReflexName('TestReflex#create') === 'Test')
+    })
+  })
+
+  describe("when it can't extract the reflex name", () => {
+    it('returns an empty string', () => {
+      assert(extractReflexName('nope') === '')
+    })
+  })
+})

--- a/javascript/test/utils.extractReflexName.test.js
+++ b/javascript/test/utils.extractReflexName.test.js
@@ -14,6 +14,12 @@ describe('extractReflexName', () => {
     })
   })
 
+  describe("when it does not include 'Reflex'", () => {
+    it('returns a reflex name', () => {
+      assert(extractReflexName('Test#create') === 'Test')
+    })
+  })
+
   describe("when it can't extract the reflex name", () => {
     it('returns an empty string', () => {
       assert(extractReflexName('nope') === '')

--- a/javascript/utils.js
+++ b/javascript/utils.js
@@ -32,3 +32,9 @@ export const debounce = (callback, delay = 250) => {
     }, delay)
   }
 }
+
+export const extractReflexName = reflexString => {
+  const match = reflexString.match(/(.*->)?(.*)Reflex/)
+
+  return match ? match[2] : ''
+}

--- a/javascript/utils.js
+++ b/javascript/utils.js
@@ -34,7 +34,7 @@ export const debounce = (callback, delay = 250) => {
 }
 
 export const extractReflexName = reflexString => {
-  const match = reflexString.match(/(.*->)?(.*)Reflex/)
+  const match = reflexString.match(/(?:.*->)?(.*?)(?:Reflex)?#/)
 
-  return match ? match[2] : ''
+  return match ? match[1] : ''
 }


### PR DESCRIPTION
# Bug fix

## Description

When selecting the controller for a specific reflex, we were always selecting the first one. This caused us to run the lifecycle methods of the wrong controller if the user specified other controllers via `data-controller`. This commit finds the correct controller and if not found, it uses the default stimulus controller as before.

Some pseudocode examples of what was happening:

Before:

```js
// Given these controllers (identifiers here)
const controllers = ['sortable', 'ui', 'autogrow', 'test']
// When reflex name was
const reflex = 'click->TestReflex#create'
// We were doing
controllers[0]
// Which selected the wrong controller. i.e. 'sortable' instead of 'test'
```

```js
// Given these controllers (identifiers here)
const controllers = ['sortable', 'ui', 'autogrow', 'test']
// When reflex name was
const reflex = 'click->TestReflex#create'
// We now do
controllers.find(controller => controller.identifier === reflexName)
// Which selects the correct controller. i.e. 'test'
```

Fixes https://github.com/hopsoft/stimulus_reflex/issues/225

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing

## Notes

I'm marking this as WIP as I'm not sure which branch this should go to, or other build steps. 