### PR TITLE
adds params documentation

### DIFF
--- a/docs/reflexes.md
+++ b/docs/reflexes.md
@@ -60,6 +60,7 @@ StimulusReflex makes the following properties available to the developer inside 
 * `session` - the `ActionDispatch::Session` store for the current visitor
 * `url` - the URL of the page that triggered the reflex
 * `element` - a Hash like object that represents the HTML element that triggered the reflex
+* `params` - form parameters, if the reflex originated from within a form
 
 {% hint style="danger" %}
 `reflex` and `process` are reserved words inside Reflex classes. You cannot create Reflex actions with these names.
@@ -109,6 +110,22 @@ When StimulusReflex is rendering your template, an instance variable named **@st
 
 You can use this flag to create branching logic to control how the template might look different if it's a Reflex vs normal page refresh.
 {% endhint %}
+
+### Params
+
+Provides serialization for form params as `ActionController::Parameters` of the parent form element. 
+You can access the params directly in your reflex and use exaclty as you do in ActionControllers, useful for validations and updating multiple attributes of models.
+
+To modify `params` before sending them you can use `beforeReflex` lifecycle event using `element.refelexData`, for example:
+
+```javascript
+export default class extends ApplicationController {
+  beforeReflex(element) {
+    const { params } = element.reflexData
+    element.reflexData.params = { ...params, foo: true, bar: false }
+  }
+}
+```
 
 ### Reflex exceptions are rescuable
 

--- a/docs/reflexes.md
+++ b/docs/reflexes.md
@@ -60,7 +60,7 @@ StimulusReflex makes the following properties available to the developer inside 
 * `session` - the `ActionDispatch::Session` store for the current visitor
 * `url` - the URL of the page that triggered the reflex
 * `element` - a Hash like object that represents the HTML element that triggered the reflex
-* `params` - form parameters, if the reflex originated from within a form
+* `params` - query and path params for the page that triggered the reflex and serialized params of the closest form
 
 {% hint style="danger" %}
 `reflex` and `process` are reserved words inside Reflex classes. You cannot create Reflex actions with these names.


### PR DESCRIPTION
# Documentation for Params

## Description

Adds minimal description of `params` usage in ReflexControllers and how to change params before submitting

"Fixes" missing documentation https://github.com/hopsoft/stimulus_reflex/pull/204#issuecomment-632096254

## Where to put this?

Not sure, if this is really the right place to put it. As the javascript example does not really fit into the section of the Reflex Class description. I feel like this documentation does not fit well with the rest, should there maybe a separate page specifically on form handling?

Please let me know, how I can best help to document this, or whether you would prefer to do this yourself.