### PR TITLE
merges insteads of overwrites params for reflex actions with form data

### DIFF
--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -77,7 +77,7 @@ class StimulusReflex::Reflex
       )
       path_params = Rails.application.routes.recognize_path_with_request(req, url, req.env[:extras] || {})
       req.env.merge(ActionDispatch::Http::Parameters::PARAMETERS_KEY => path_params)
-      req.env["action_dispatch.request.parameters"] = @params
+      req.env["action_dispatch.request.parameters"] = req.parameters.merge(@params)
       req.tap { |r| r.session.send :load! }
     end
   end


### PR DESCRIPTION
# Bug fix for loosing query and path parameters when using form params in reflex action

## Description

Currently `params` is not behaving as expected in an `ApplicationReflex`. If I use `params` in a Reflex

```ruby
class ExampleReflex < ApplicationReflex
   def example
      params
   end
````
You run into trouble, if you controller action depends on path or query parameters, as these get overwritten. So you will run into ActiveRecord errors like `StimulusReflex::Channel Failed to re-render http://localhost:3000/example_model/7/edit Couldn't find ExampleModel without an ID`

Same goes for query parameters. This happens because Action Dispatch has a guard clause that return whatever is set in `action_dispatch.request.parameters` if it is set, before handling query and path parameters, see https://github.com/rails/rails/blob/b4bf143d6ab10bf269777385cdaa2111b9c4159b/actionpack/lib/action_dispatch/http/parameters.rb#L52

So we need to merge and not just set `action_dispatch.request.parameters`

## The change

Is simple, just merge the req.parameters with the serializes params of the request. 

## Why should this be added

This gives access to all the params of the request not just the form params, prevents confusion, when the subsequent controller action fails, because it is missing params.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
