### PR TITLE
__perform had a bug where it was only ever calling the first event

### DIFF
--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -173,8 +173,11 @@ const extendStimulusController = controller => {
         if (!reflex || !reflex.trim().length) element = element.parentElement
       }
 
-      attributeValues(reflex).forEach(reflex =>
-        this.stimulate(reflex.split('->')[1], element)
+      this.stimulate(
+        attributeValues(reflex)
+          .find(reflex => reflex.split('->')[0] === event.type)
+          .split('->')[1],
+        element
       )
     }
   })


### PR DESCRIPTION
# bug fix

## Description

We accept multiple events routing to multiple reflexes, but somehow a bug slipped in that was only catching the first event

## Why should this be added

Obvious bug

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
