### PR TITLE
Add more smarts to __perform

### DIFF
--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -160,9 +160,6 @@ const extendStimulusController = controller => {
     // Wraps the call to stimulate for any data-reflex elements.
     // This is internal and should not be invoked directly.
     __perform (event) {
-      event.preventDefault()
-      event.stopPropagation()
-
       let element = event.target
       let reflex
 
@@ -173,12 +170,15 @@ const extendStimulusController = controller => {
         if (!reflex || !reflex.trim().length) element = element.parentElement
       }
 
-      this.stimulate(
-        attributeValues(reflex)
-          .find(reflex => reflex.split('->')[0] === event.type)
-          .split('->')[1],
-        element
+      const match = attributeValues(reflex).find(
+        reflex => reflex.split('->')[0] === event.type
       )
+
+      if (match) {
+        event.preventDefault()
+        event.stopPropagation()
+        this.stimulate(match.split('->')[1], element)
+      }
     }
   })
 }


### PR DESCRIPTION
# Fix

## Description

Improved on the fix from #234 and only stimuluates when a match is found.
Also, only prevents default event behavior when a match is found.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing