### PR TITLE
Add instructions for pulling the user id out of session storage

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -126,6 +126,37 @@ end
 ```
 {% endcode %}
 
+
+### Sorcery-based Authentication (user id is in session storage)
+
+If you're using [Sorcery](https://github.com/Sorcery/sorcery) for authentication, you'd need to pull the user id out of the session store.
+
+{% code title="app/channels/application\_cable/connection.rb" %}
+```ruby
+module ApplicationCable
+  class Connection < ActionCable::Connection::Base
+    identified_by :current_user
+
+    def connect
+      self.current_user = find_verified_user
+    end
+
+    protected
+
+    def find_verified_user
+      user_id = request.session.fetch("user_id", nil)
+      
+      if verified_user = User.find_by(id: user_id)
+        verified_user
+      else
+        reject_unauthorized_connection
+      end
+    end
+  end
+end
+```
+{% endcode %}
+
 Now you're free to delegate current\_user. Be home by lunch:
 
 {% code title="app/reflexes/example\_reflex.rb" %}


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)
documentation

## Description

The auth guide is great! Thank you for that.

I am using Sorcery for authentication, where the `user_id` is [stored in a session](https://github.com/Sorcery/sorcery/blob/31a055b2b6f26261958c348fcf9602f87a558ab5/lib/sorcery/controller.rb#L117), and not in a cookie, which might be the case for other authentication libraries. It took me a bit of searching to understand how to access the session from the Action Cable connection.

## Why should this be added

Save time for other users with `user_id` in session storage.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
