### PR TITLE
Update install.rake to handle Typescript

### DIFF
--- a/lib/tasks/stimulus_reflex/install.rake
+++ b/lib/tasks/stimulus_reflex/install.rake
@@ -11,11 +11,16 @@ namespace :stimulus_reflex do
     FileUtils.mkdir_p Rails.root.join("app/javascript/controllers"), verbose: true
     FileUtils.mkdir_p Rails.root.join("app/reflexes"), verbose: true
 
-    filepath = if File.exist? Rails.root.join("app/javascript/controllers/index.js")
-      Rails.root.join("app/javascript/controllers/index.js")
-    else
-      Rails.root.join("app/javascript/packs/application.js")
-    end
+    filepath = %w[
+      app/javascript/controllers/index.js
+      app/javascript/controllers/index.ts
+      app/javascript/packs/application.js
+      app/javascript/packs/application.ts
+    ]
+      .select { |path| File.exist?(path) }
+      .map { |path| Rails.root.join(path) }
+      .first
+
     puts "Updating #{filepath}"
     lines = File.open(filepath, "r") { |f| f.readlines }
 


### PR DESCRIPTION
# Enhancement / Bug Fix

## Description

When using typescript, you will have `index.ts` instead of `index.js` or `application.ts` instead of `application.js`. 

Prior to this change, running `bundle exec rails stimulus_reflex:install` fails because neither `index.js` nor `application.js` will be found.

Now with this change, it will work when using typescript, the contents appended to these files work in Typescript without a problem.

## Why should this be added

This reduces install friction for Typescript users.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
