### PR TITLE
always calls params to persist them into controller action

### DIFF
--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -53,7 +53,8 @@ class StimulusReflex::Reflex
     @element = element
     @selectors = selectors
     @method_name = method_name
-    @params = params
+    @form_params = params
+    self.params
   end
 
   def request
@@ -77,7 +78,7 @@ class StimulusReflex::Reflex
       )
       path_params = Rails.application.routes.recognize_path_with_request(req, url, req.env[:extras] || {})
       req.env.merge(ActionDispatch::Http::Parameters::PARAMETERS_KEY => path_params)
-      req.env["action_dispatch.request.parameters"] = req.parameters.merge(@params)
+      req.env["action_dispatch.request.parameters"] = req.parameters.merge(@form_params)
       req.tap { |r| r.session.send :load! }
     end
   end


### PR DESCRIPTION
# Bug Fix
## Description

### Current behaviour:

* If we don't call `params` in the reflex, the form parameters will not be available in the controller action, it will only have params like `:controller` and `:action`

You can see this behavior in the expo with my PR for the validation example: https://github.com/hopsoft/stimulus_reflex_expo/pull/44/files , in the reflex I call `params` otherwise it will not validate, as the form params are missing.

### Expected behaviour

calling `params` in then controller should yield the same result as calling `params` in the reflex, **without** having to call `params` in the reflex first.

## Why should this be added

I think the current behavior is unexpected. I am however unsure how to best do this, and I am not adressing the root problem.

Also I made the instance_variables a bit clearer, as there is a `params` argument in `initialize`

## Why is this happening

I don't fully understand it: `@_params` is used in the controller action to access to params. But I did not find out how it is getting set. I thought it was in  [ActionPack Meta Line 159](https://github.com/rails/rails/blob/0cffb053a6b1b23b74243b829df768db97ccd004/actionpack/lib/action_controller/metal.rb#L159), but breakpoints there did not stop for me, so I am not sure if my tooling is failing me, or if this is really not called

But the suggested code makes sure that the `@_params` is set, so the right params come out for the controller action. This alleviates the problem, but does not solve the root problem of why this is happening in the first place. The header `["action_dispatch.request.parameters"]` has all the params and should be used. 🤷 

## Nicer code?

maybe doing it like this would be prettier and more explicit

```ruby
def initialize
  …
  @_params = ActionController::Parameters.new(request.parameters)
end

def params
  @_params
end

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
