### PR TITLE
warn against collections of identical elements that trigger reflexes

### DIFF
--- a/javascript/attributes.js
+++ b/javascript/attributes.js
@@ -136,6 +136,11 @@ export const findElement = attributes => {
     }
   }
 
+  if (elements.length > 1)
+    console.warn(
+      'StimulusReflex found multiple identical elements which match the signature of the element which triggered this Reflex. Lifecycle callbacks and events cannot be raised unless your elements have distinguishing characteristics. Consider adding an #id or a randomized data-key to the element.'
+    )
+
   const element = elements.length === 1 ? elements[0] : null
   return element
 }


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Enhancement

## Description

This PR emits a console warning message in scenarios where multiple identical elements match the selector generated by the `findElement(attributes)` method in `attributes.js`.

## Why should this be added

After a Reflex morphs the page, all elements are new. In order to emit afterReflex and reflexSuccess callbacks/events, findElement() needs to return exactly one element. If no elements are found, an error is raised. However, if more than one element is found, we silently continue and no lifecycle events can be completed.

A developer wrote in with a scenario that had multiple identical elements which called the same Reflex but would not emit afterReflex events. While we cannot fix what we don't know, we can help developers realize when they must put ids on their elements. I will be making things more clear in the documentation as well.

Interesting to note: React has a similar warning when collections are passed without identifier keys.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
