### PR TITLE
Fix cases where plural reflexes were unresolved

### DIFF
--- a/lib/stimulus_reflex/channel.rb
+++ b/lib/stimulus_reflex/channel.rb
@@ -21,7 +21,7 @@ class StimulusReflex::Channel < ActionCable::Channel::Base
     selectors = data["selectors"] = ["body"] if selectors.blank?
     target = data["target"].to_s
     reflex_name, method_name = target.split("#")
-    reflex_name = reflex_name.classify
+    reflex_name = reflex_name.camelize
     reflex_name = reflex_name.end_with?("Reflex") ? reflex_name : "#{reflex_name}Reflex"
     arguments = (data["args"] || []).map { |arg| object_with_indifferent_access arg }
     element = StimulusReflex::Element.new(data)


### PR DESCRIPTION
## Type of PR (feature, enhancement, bug fix, etc.)

fix

## Description

If you have a reflex with a plural name like `CampaignsReflex`, and call it with `click->Campaigns#do_something`, `"Campaigns"` will incorrectly be resolved to `"Campaign"`.

From here: https://discordapp.com/channels/629472241427415060/629472241427415062/727195517351886968

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
