### PR TITLE
Returns more helpful error message if Reflex doesn't exist

### DIFF
--- a/javascript/log.js
+++ b/javascript/log.js
@@ -53,6 +53,8 @@ function error (response) {
     payload: event.detail.stimulusReflex,
     element
   })
+  if (detail.stimulusReflex.serverMessage.body)
+    console.error(`\u2B05 ${target}`, detail.stimulusReflex.serverMessage.body)
   delete logs[reflexId]
 }
 

--- a/lib/stimulus_reflex/channel.rb
+++ b/lib/stimulus_reflex/channel.rb
@@ -33,7 +33,7 @@ class StimulusReflex::Channel < ActionCable::Channel::Base
         reflex = reflex_class.new(self, url: url, element: element, selectors: selectors, method_name: method_name, params: params)
         delegate_call_to_reflex reflex, method_name, arguments
       rescue => invoke_error
-        reflex.rescue_with_handler(invoke_error) if reflex
+        reflex&.rescue_with_handler(invoke_error)
         message = exception_message_with_backtrace(invoke_error)
         return broadcast_message subject: "error", body: "StimulusReflex::Channel Failed to invoke #{target}! #{url} #{message}", data: data
       end
@@ -44,7 +44,7 @@ class StimulusReflex::Channel < ActionCable::Channel::Base
         begin
           render_page_and_broadcast_morph reflex, selectors, data
         rescue => render_error
-          reflex.rescue_with_handler(render_error) if reflex
+          reflex&.rescue_with_handler(render_error)
           message = exception_message_with_backtrace(render_error)
           broadcast_message subject: "error", body: "StimulusReflex::Channel Failed to re-render #{url} #{message}", data: data
         end

--- a/lib/stimulus_reflex/channel.rb
+++ b/lib/stimulus_reflex/channel.rb
@@ -33,7 +33,7 @@ class StimulusReflex::Channel < ActionCable::Channel::Base
         reflex = reflex_class.new(self, url: url, element: element, selectors: selectors, method_name: method_name, params: params)
         delegate_call_to_reflex reflex, method_name, arguments
       rescue => invoke_error
-        reflex.rescue_with_handler(invoke_error)
+        reflex.rescue_with_handler(invoke_error) if reflex
         message = exception_message_with_backtrace(invoke_error)
         return broadcast_message subject: "error", body: "StimulusReflex::Channel Failed to invoke #{target}! #{url} #{message}", data: data
       end
@@ -44,7 +44,7 @@ class StimulusReflex::Channel < ActionCable::Channel::Base
         begin
           render_page_and_broadcast_morph reflex, selectors, data
         rescue => render_error
-          reflex.rescue_with_handler(render_error)
+          reflex.rescue_with_handler(render_error) if reflex
           message = exception_message_with_backtrace(render_error)
           broadcast_message subject: "error", body: "StimulusReflex::Channel Failed to re-render #{url} #{message}", data: data
         end


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Enhancement

## Description

Added conditional checks to rescue block so that error handling doesn't assume Reflex was created successfully. Also modified client logging to emit the server error.

Fixes #253

## Why should this be added

This should help resolve issues with incorrectly named or addressed Reflex classes.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
