### PR TITLE
Limit MutationObserver mutations

### DIFF
--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -244,13 +244,21 @@ const setupDeclarativeReflexes = debounce(() => {
       })
       const controllerValue = attributeValue(controllers)
       const actionValue = attributeValue(actions)
-      if (controllerValue) {
+      if (
+        controllerValue &&
+        element.getAttribute(stimulusApplication.schema.controllerAttribute) !=
+          controllerValue
+      ) {
         element.setAttribute(
           stimulusApplication.schema.controllerAttribute,
           controllerValue
         )
       }
-      if (actionValue)
+      if (
+        actionValue &&
+        element.getAttribute(stimulusApplication.schema.actionAttribute) !=
+          actionValue
+      )
         element.setAttribute(
           stimulusApplication.schema.actionAttribute,
           actionValue
@@ -327,23 +335,11 @@ if (!document.stimulusReflexInitialized) {
 
   window.addEventListener('load', () => {
     setupDeclarativeReflexes()
-
-    const observer = new MutationObserver(mutations => {
-      mutations.forEach(mutation => {
-        const shouldMutate =
-          !mutation.oldValue ||
-          (mutation.oldValue != 'stimulus-reflex' &&
-            !mutation.oldValue.includes('__perform'))
-
-        if (shouldMutate) setupDeclarativeReflexes()
-      })
-    })
-
+    const observer = new MutationObserver(setupDeclarativeReflexes)
     observer.observe(document.documentElement, {
       attributes: true,
       childList: true,
-      subtree: true,
-      attributeOldValue: true
+      subtree: true
     })
   })
 

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -327,11 +327,23 @@ if (!document.stimulusReflexInitialized) {
 
   window.addEventListener('load', () => {
     setupDeclarativeReflexes()
-    const observer = new MutationObserver(setupDeclarativeReflexes)
+
+    const observer = new MutationObserver(mutations => {
+      mutations.forEach(mutation => {
+        const shouldMutate =
+          !mutation.oldValue ||
+          (mutation.oldValue != 'stimulus-reflex' &&
+            !mutation.oldValue.includes('__perform'))
+
+        if (shouldMutate) setupDeclarativeReflexes()
+      })
+    })
+
     observer.observe(document.documentElement, {
       attributes: true,
       childList: true,
-      subtree: true
+      subtree: true,
+      attributeOldValue: true
     })
   })
 


### PR DESCRIPTION
# Bug Fix, Maybe?

## Description

**This is a theory, with a potential solution. I could be way off.**

The current `MutationObserver` fires in an endless loop, because `setupDeclarativeReflexes` (the code called from the observer) is making a mutation, hence rerunning `setupDeclarativeReflexes`.

Safari and Chrome seem to handle this ok. In Firefox, however, it causes a nasty flicker on selects. If you go to open a select dropdown, it never lets you choose another option, it continues to re-select the original value.

If you `console.log` anything inside of `setupDeclarativeReflexes` it causes Firefox (on my machine) to lock up within a second, requiring a force quit.

I believe this is the section of code causing the flicker, because if you stop the observer the flicker stops (but so does the SR functionality, obviously). If you bump the `debounce` time for `setupDeclarativeReflexes` to something higher, the flicker still happens, but at a slower pace.

The `setupDeclarativeReflexes` function seems to do one of two mutating things:

1. Adding `stimulus-reflex` to `data-controller`
2. Adding `[event]->[Reflex]#__perform` to `data-action`

I believe we can stop the endless loop by observing the mutations and not rerunning `setupDeclarativeReflexes` if either of these two mutations performed.

Fixes #251 

## Why should this be added

This feels like... not what we want? 

Unfortunately, my `MutationObserver` knowledge is laughable, as we've only used it a handful of times in our own application. But, I wanted to do my part to try and help solve this issue.

I've forked this JS code into a repo to run against our app and _**so far**_ it appears to be working. Granted, our app doesn't cover all the other ways people use Stimulus Reflex. 😅 

As **always**, I'm open to suggestions and making changes.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
