### PR TITLE
Fallback to first Stimulus controller in array

### DIFF
--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -263,7 +263,7 @@ const setupDeclarativeReflexes = debounce(() => {
 // identifier. e.g. Given these controller identifiers ['foo', 'bar', 'test'],
 // it would select the 'test' controller.
 const findControllerByReflexString = (reflexString, controllers) => {
-  return controllers.find(controller => {
+  const controller = controllers.find(controller => {
     if (!controller.identifier) return
 
     return (
@@ -271,6 +271,8 @@ const findControllerByReflexString = (reflexString, controllers) => {
       controller.identifier.toLowerCase()
     )
   })
+
+  return controller || controllers[0]
 }
 
 // compute the DOM element(s) which will be the morph root


### PR DESCRIPTION
# Bug Fix

## Description

#226 does the great work of automatically using a matching Stimulus controller name with a matching Reflex. 👏🎉 

Unfortunate for us, is that we do some aerobatics with our naming and namespaces. Our Stimulus controllers use a custom name that doesn't match the reflex. This means that `findControllerByReflexString` returns `null` and we lose all our JS callback functionality.

I think there's a middle ground until we can [figure out a way around this](https://github.com/hopsoft/stimulus_reflex/pull/226#issuecomment-652549495). We can default to looking for a matching controller name, and falling back to `controllers[0]` (as done before) if a match isn't found.

## Why should this be added

This was a pretty unexpected, surprising change in functionality for us. At most, I'd like to continue using custom Stimulus controller names. At minimum, I'd like to put off a requirement for matching controller/reflex names for just a bit if possible. 🙏 

I think this change gives priority to those who have matching Stimulus Reflex controller/reflex names, while still giving the rest of us room to make messes. 😉 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
