### PR TITLE
conditionally set children_only in morph

### DIFF
--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -108,10 +108,11 @@ class StimulusReflex::Reflex
   end
 
   def enqueue_selector_broadcast(selector, html)
+    document = Nokogiri::HTML(html)
     cable_ready[channel.stream_name].morph(
       selector: selector,
       html: html,
-      children_only: true,
+      children_only: !document.css(selector).present?,
       permanent_attribute_name: permanent_attribute_name
     )
   end


### PR DESCRIPTION
This is related to issue 1 from discord. 

> It's starting to feel like :selector morphs should be performed as children_only: false which in real terms is like shifting from modifying innerHTML to outerHTML - unlike :page morphs, the container element would be re-written. This is because we want re-rendering partials and components to follow the principle of least surprise; right now if you re-render a partial inside a container you'll end up with a 2nd copy of the container element in the container element. Note: morphdom gets weird about replacing the body tag, so if you morph "body" it will still be children only.

I didn't think just setting children_only to false for selector morphs was really the right solution because that's not strictly the problem. The *problem* if if you have some selector, say `#foo`, and you set the html of this component to `<div id="foo">..</div>`, then you now have conflicting elements in your DOM that is going to confuse all of your selectors. In this specific case, you want children_only to be false. 

So that's what this PR tries to do. 

There's a related PR in for `cable_ready` that I had to make to even get this to work with `children_only: false`. https://github.com/hopsoft/cable_ready/pull/58


## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
