### PR TITLE
potential fix

### DIFF
--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -114,7 +114,7 @@ class StimulusReflex::Reflex
       children_only: true,
       permanent_attribute_name: permanent_attribute_name
     }
-    operation = (html.empty? || html.start_with?("<") == false) ? :inner_html : :morph
+    operation = html.empty? || html.start_with?("<") == false ? :inner_html : :morph
     opts[:children_only] = false if operation == :morph && selector != "body" && Nokogiri::HTML(html).at_css(selector)
     cable_ready[channel.stream_name].send(operation, opts)
   end

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -108,12 +108,15 @@ class StimulusReflex::Reflex
   end
 
   def enqueue_selector_broadcast(selector, html)
-    cable_ready[channel.stream_name].morph(
+    opts = {
       selector: selector,
       html: html,
       children_only: true,
       permanent_attribute_name: permanent_attribute_name
-    )
+    }
+    operation = (html.empty? || html.start_with?("<") == false) ? :inner_html : :morph
+    opts[:children_only] = false if operation == :morph && selector != "body" && Nokogiri::HTML(html).at_css(selector)
+    cable_ready[channel.stream_name].send(operation, opts)
   end
 
   def controller


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bug fix

## Description

Decide between morph with children, morph without children (partials) or inner_html based on the following pseudo-Ruby:

```rb
return morph children_only: true if selector == "body"
if html.empty? or html.start_with("<") == false
  return inner_html.
else
  doc = nokogiri(html)
  return morph children_only: false if doc.top_level_tag.selector == selector
  return morph children_only: true
end
```

In the end, I didn't attempt to provide a 3rd parameter argument because there really is only one condition where you'd want to use `children_only: false` and if you're that one weirdo in a thousand that has an exception, you can always call CableReady directly.

Fixes #211 

## Why should this be added

Put me out of my misery

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
