### PR TITLE
alternate solution

### DIFF
--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -108,9 +108,11 @@ class StimulusReflex::Reflex
   end
 
   def enqueue_selector_broadcast(selector, html)
+    fragment = Nokogiri::HTML(html)
+    parent = fragment.at_css(selector)
     cable_ready[channel.stream_name].morph(
       selector: selector,
-      html: html,
+      html: parent.present? ? parent.inner_html : fragment.to_html,
       children_only: true,
       permanent_attribute_name: permanent_attribute_name
     )


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

bug fix

## Description

Once I finished the previous implementation, of course the refactoring started. This solution is actually inspired by what @joshleblanc proposed for CableReady.

First, I am not keen on using inner_html because it doesn't respect `data-reflex-permanent` in any case. So I decided to just go with it and work out a version that uses Nokogirl for all calls.

The breakthough came from realizing that it's not replacing the container that's important, but modifying the content depending on the context. If you're updating a partial/component, you want fragment.inner_html, otherwise fragment.to_html. Therefore, **this version does not require children_only: false**

The next thing that I've figured out is that the data-reflex-permanent bug has been there all along! We were just never stumbling into it.

In order for the `data-reflex-permanent` to work, two things have to be true: first, **it just does not work on text nodes**. You have to wrap all text in at least a `span` or else it will just overwrite even if it's marked as permanent. The second detail seems to be that it only respects `permanent` if the selector is the same.

Note: I'm basically falling asleep on my keyboard so I intend to finish my research tomorrow, but I wanted to share now so people don't waste time.

There's no getting around it: we're going to have to give people some rules/best practices for calling morphs. Either that or we can detect text and wrap it in a `span` which might not be a welcome addition.

Fixes #211

## Why should this be added

For future generations

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
