### PR TITLE
coerce html arguments to string type

### DIFF
--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -98,7 +98,9 @@ class StimulusReflex::Reflex
       @morph_mode = StimulusReflex::SelectorMorphMode.new
       selectors = Hash[selectors, html] unless selectors.is_a?(Hash)
       selectors.each do |selector, html|
-        enqueue_selector_broadcast selector, html.to_s
+        html = html.to_s
+        html = "<span>#{html}</span>" unless html.include?("<")
+        enqueue_selector_broadcast selector, html
       end
       cable_ready.broadcast
     end

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -96,12 +96,9 @@ class StimulusReflex::Reflex
     else
       raise StandardError.new("Cannot call :selector morph after :nothing morph") if @morph_mode.nothing?
       @morph_mode = StimulusReflex::SelectorMorphMode.new
-      if selectors.is_a?(Hash)
-        selectors.each do |selector, html|
-          enqueue_selector_broadcast selector, html
-        end
-      else
-        enqueue_selector_broadcast selectors, html
+      selectors = Hash[selectors, html] unless selectors.is_a?(Hash)
+      selectors.each do |selector, html|
+        enqueue_selector_broadcast selector, html.to_s
       end
       cable_ready.broadcast
     end


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

bug fix

## Description

@hopsoft noticed that `morph "#id", 5` would explode. I refactored the morph method to coerce html arguments into strings.

## Why should this be added

Edge case handling.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
