### PR TITLE
Fix argument of type object always being assigned to options

### DIFF
--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -100,9 +100,9 @@ const extendStimulusController = controller => {
       if (
         args[0] &&
         typeof args[0] == 'object' &&
-        Object.keys(args[0])
-          .filter(key => ['attrs', 'selectors', 'reflexId'].includes(key))
-          .includes(true)
+        Object.keys(args[0]).filter(key =>
+          ['attrs', 'selectors', 'reflexId'].includes(key)
+        ).length
       ) {
         const opts = args.shift()
         Object.keys(opts).forEach(o => (options[o] = opts[o]))

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -100,9 +100,9 @@ const extendStimulusController = controller => {
       if (
         args[0] &&
         typeof args[0] == 'object' &&
-        Object.keys(args[0]).filter(key =>
-          ['attrs', 'selectors', 'reflexId'].includes(key)
-        )
+        Object.keys(args[0])
+          .filter(key => ['attrs', 'selectors', 'reflexId'].includes(key))
+          .includes(true)
       ) {
         const opts = args.shift()
         Object.keys(opts).forEach(o => (options[o] = opts[o]))


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)
Bug Fix


## Description
The first argument of type "object" being passed into this.stimulate() will always be assigned to `const options`.

The check to see if an object is an options object will always return true... even if the option keys are not present in the object.

Added an additional check on the 3rd expression to check if there were any `true` values in the array returned by `Object.keys(args[0]).filter( ... )`.

Fixes issue #278 

## Why should this be added

Because arguments of type "object" end up being assigned to options when they are not supposed to.

(I'm assuming this is unintended based on the the documentation of ["Receiving arguments"](https://docs.stimulusreflex.com/reflexes#receiving-arguments) where a reflex can receive an object as the first argument.)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
