### PR TITLE
Allow morphs to run before triggering success/after

### DIFF
--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -378,13 +378,15 @@ if (!document.stimulusReflexInitialized) {
       data: promise && promise.data
     }
 
-    if (promise) {
-      delete promises[reflexId]
-      promise.resolve(response)
-    }
+    setTimeout(() => {
+      if (promise) {
+        delete promises[reflexId]
+        promise.resolve(response)
+      }
 
-    dispatchLifecycleEvent('success', element)
-    if (debugging) Log.success(response)
+      dispatchLifecycleEvent('success', element)
+      if (debugging) Log.success(response)
+    })
   }
   document.addEventListener(
     'cable-ready:before-inner-html',


### PR DESCRIPTION
# Bug fix

## Description

Wait for the next tick in the event loop before triggering success/after lifecycle events & callbacks.

SEE: https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout

> If [the `delay`] parameter is omitted, a value of 0 is used, meaning execute "immediately", or more accurately, the next event cycle.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing