### PR TITLE
Add instructions for existing projects

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -15,8 +15,14 @@ You can find additional information for supporting Rails 5.2+ below.
 StimulusReflex relies on [Stimulus](https://stimulusjs.org/), an excellent library from the creators of Rails. You can easily install StimulusReflex to new and existing Rails projects.
 
 ```bash
+# For new projects
 rails new myproject --webpack=stimulus
 cd myproject
+
+# For existing projects
+bundle exec rails webpacker:install:stimulus
+
+# For both project types
 bundle add stimulus_reflex
 bundle exec rails stimulus_reflex:install
 ```


### PR DESCRIPTION
# Docs

## Description

The sentence above this change mentions easily setting up StimulusReflex for new and existing rails projects, but then proceeded to only give instructions for new projects.

> You can easily install StimulusReflex to new and existing Rails projects.

This commit fixes that.

## Why should this be added

This helps people with adding Stimulus Reflux to existing projects

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing

