### PR TITLE
Check if reflex exists before using it

### DIFF
--- a/lib/stimulus_reflex/channel.rb
+++ b/lib/stimulus_reflex/channel.rb
@@ -32,9 +32,15 @@ class StimulusReflex::Channel < ActionCable::Channel::Base
         reflex = reflex_class.new(self, url: url, element: element, selectors: selectors, method_name: method_name, permanent_attribute_name: permanent_attribute_name, params: params)
         delegate_call_to_reflex reflex, method_name, arguments
       rescue => invoke_error
-        reflex&.rescue_with_handler(invoke_error)
         message = exception_message_with_backtrace(invoke_error)
-        return reflex.broadcast_message subject: "error", body: "StimulusReflex::Channel Failed to invoke #{target}! #{url} #{message}", data: data
+        body = "StimulusReflex::Channel Failed to invoke #{target}! #{url} #{message}"
+        if reflex
+          reflex.rescue_with_handler(invoke_error)
+          reflex.broadcast_message subject: "error", body: body, data: data
+        else
+          logger.error "\e[31m#{body}\e[0m"
+        end
+        return 
       end
 
       if reflex.halted?

--- a/lib/stimulus_reflex/channel.rb
+++ b/lib/stimulus_reflex/channel.rb
@@ -40,7 +40,7 @@ class StimulusReflex::Channel < ActionCable::Channel::Base
         else
           logger.error "\e[31m#{body}\e[0m"
         end
-        return 
+        return
       end
 
       if reflex.halted?


### PR DESCRIPTION

Let me know if I should make any changes

# Bug fix

## Description

If `reflex` isn't properly assigned in the begin block, then the `rescue` block will throw when it tries to broadcast a message.

I just pulled `logger.error` from `commit_session`. Most of the error handling is just sent back down the wire, so I'm not confident what error handling you guys find acceptable. I actually think it might be a better idea to just re-raise the error, because failing to find the reflex is a critical error. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
