### PR TITLE
Avoid mismatching client and server versions

### DIFF
--- a/lib/tasks/stimulus_reflex/install.rake
+++ b/lib/tasks/stimulus_reflex/install.rake
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 require "fileutils"
+require_relative "../../stimulus_reflex/version"
 
 namespace :stimulus_reflex do
   desc "Install StimulusReflex in this application"
   task install: :environment do
     system "bundle exec rails webpacker:install:stimulus"
-    system "yarn add stimulus_reflex"
+    gem_version = StimulusReflex::VERSION.gsub(".pre", "-pre")
+    system "yarn add stimulus_reflex@#{gem_version}"
 
     FileUtils.mkdir_p Rails.root.join("app/javascript/controllers"), verbose: true
     FileUtils.mkdir_p Rails.root.join("app/reflexes"), verbose: true


### PR DESCRIPTION
# Enhancement

Me and @rolandstuder paired up together on this enhancement.

## Description

This fix improves installation task of Stimulus Reflex.

Following the [setup](https://docs.stimulusreflex.com/setup#command-line-install):
```
bundle add stimulus_reflex
bundle exec rails stimulus_reflex:install
```
latest **stable** version of `stimulus_reflex` gem (`3.2`) gets added to `Gemfile` with bundler and the exact **latest** version of `stimulus_reflex` package (`3.3.0-pre3`) gets added to `package.json` with yarn. They do mismatch!

Fixes https://github.com/hopsoft/stimulus_reflex/issues/294

## Why should this be added

This PR avoids StimulusReflex client and server having mismatched versions. It is a good practice to keep the gem and the npm package versions in sync.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing

## Questions

1) Does `stimulus_reflex` [version](https://github.com/hopsoft/stimulus_reflex/blob/master/javascript/package.json#L3) in `package.json` get updated automatically when gem [version](https://github.com/hopsoft/stimulus_reflex/blob/master/lib/stimulus_reflex/version.rb#L4) is increased?
2) It would be nice to run some check such as `verify_server_version` in order to display a warning about mismatched client and server versions and act accordingly. The question is: where should it happen? On [initialize](https://github.com/hopsoft/stimulus_reflex/blob/master/lib/stimulus_reflex/reflex.rb#L52) / [process](https://github.com/hopsoft/stimulus_reflex/blob/master/lib/stimulus_reflex/reflex.rb#L119) of `Reflex`?