### PR TITLE
Fix timing issues with post-Reflex lifecycle callbacks

### DIFF
--- a/javascript/lifecycle.js
+++ b/javascript/lifecycle.js
@@ -11,7 +11,7 @@ import { camelize } from './utils'
 //
 // - element - the element that triggered the reflex (not necessarily the Stimulus controller's element)
 //
-const invokeLifecycleMethod = (stage, element) => {
+const invokeLifecycleMethod = (stage, element, reflexId) => {
   if (!element || !element.reflexData) return
   const controller = element.reflexController
   const reflex = element.reflexData.target
@@ -33,7 +33,8 @@ const invokeLifecycleMethod = (stage, element) => {
         controller,
         element,
         reflex,
-        element.reflexError
+        element.reflexError,
+        reflexId
       )
     )
   }
@@ -44,7 +45,8 @@ const invokeLifecycleMethod = (stage, element) => {
         controller,
         element,
         reflex,
-        element.reflexError
+        element.reflexError,
+        reflexId
       )
     )
   }
@@ -59,15 +61,15 @@ const invokeLifecycleMethod = (stage, element) => {
 
 document.addEventListener(
   'stimulus-reflex:before',
-  event => invokeLifecycleMethod('before', event.target),
+  event => invokeLifecycleMethod('before', event.target, event.detail.reflexId),
   true
 )
 
 document.addEventListener(
   'stimulus-reflex:success',
   event => {
-    invokeLifecycleMethod('success', event.target)
-    dispatchLifecycleEvent('after', event.target)
+    invokeLifecycleMethod('success', event.target, event.detail.reflexId)
+    dispatchLifecycleEvent('after', event.target, event.detail.reflexId)
   },
   true
 )
@@ -75,8 +77,8 @@ document.addEventListener(
 document.addEventListener(
   'stimulus-reflex:selector',
   event => {
-    invokeLifecycleMethod('success', event.target)
-    dispatchLifecycleEvent('after', event.target)
+    invokeLifecycleMethod('success', event.target, event.detail.reflexId)
+    dispatchLifecycleEvent('after', event.target, event.detail.reflexId)
   },
   true
 )
@@ -84,8 +86,8 @@ document.addEventListener(
 document.addEventListener(
   'stimulus-reflex:nothing',
   event => {
-    invokeLifecycleMethod('success', event.target)
-    dispatchLifecycleEvent('after', event.target)
+    invokeLifecycleMethod('success', event.target, event.detail.reflexId)
+    dispatchLifecycleEvent('after', event.target, event.detail.reflexId)
   },
   true
 )
@@ -93,21 +95,21 @@ document.addEventListener(
 document.addEventListener(
   'stimulus-reflex:error',
   event => {
-    invokeLifecycleMethod('error', event.target)
-    dispatchLifecycleEvent('after', event.target)
+    invokeLifecycleMethod('error', event.target, event.detail.reflexId)
+    dispatchLifecycleEvent('after', event.target, event.detail.reflexId)
   },
   true
 )
 
 document.addEventListener(
   'stimulus-reflex:halted',
-  event => invokeLifecycleMethod('halted', event.target),
+  event => invokeLifecycleMethod('halted', event.target, event.detail.reflexId),
   true
 )
 
 document.addEventListener(
   'stimulus-reflex:after',
-  event => invokeLifecycleMethod('after', event.target),
+  event => invokeLifecycleMethod('after', event.target, event.detail.reflexId),
   true
 )
 
@@ -122,7 +124,7 @@ document.addEventListener(
 //
 // - element - the element that triggered the reflex (not necessarily the Stimulus controller's element)
 //
-export const dispatchLifecycleEvent = (stage, element) => {
+export const dispatchLifecycleEvent = (stage, element, reflexId) => {
   if (!element) return
   const { target } = element.reflexData || {}
   element.dispatchEvent(
@@ -131,7 +133,8 @@ export const dispatchLifecycleEvent = (stage, element) => {
       cancelable: false,
       detail: {
         reflex: target,
-        controller: element.reflexController
+        controller: element.reflexController,
+        reflexId
       }
     })
   )

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -133,7 +133,7 @@ const extendStimulusController = controller => {
       element.reflexController = this
       element.reflexData = data
 
-      dispatchLifecycleEvent('before', element)
+      dispatchLifecycleEvent('before', element, reflexId)
 
       setTimeout(() => {
         const { params } = element.reflexData || {}
@@ -168,6 +168,9 @@ const extendStimulusController = controller => {
           data
         }
       })
+
+      promise.reflexId = reflexId
+
       if (debugging) promise.catch(() => {}) // noop default catch
       return promise
     },
@@ -384,7 +387,7 @@ if (!document.stimulusReflexInitialized) {
         promise.resolve(response)
       }
 
-      dispatchLifecycleEvent('success', element)
+      dispatchLifecycleEvent('success', element, reflexId)
       if (debugging) Log.success(response)
     })
   }

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -40,7 +40,7 @@ const createSubscription = controller => {
   actionCableConsumer = actionCableConsumer || getConsumer()
   const { channel } = controller.StimulusReflex
   const identifier = JSON.stringify({ channel })
-  let totalOperations = 0
+  let totalOperations
   let reflexId
 
   controller.StimulusReflex.subscription =
@@ -48,6 +48,7 @@ const createSubscription = controller => {
     actionCableConsumer.subscriptions.create(channel, {
       received: data => {
         if (!data.cableReady) return
+        totalOperations = 0
         ;['morph', 'innerHtml'].forEach(operation => {
           if (data.operations[operation] && data.operations[operation].length) {
             if (data.operations[operation][0].stimulusReflex) {
@@ -62,7 +63,6 @@ const createSubscription = controller => {
             }
           }
         })
-
         if (promises[reflexId]) {
           promises[reflexId].totalOperations = totalOperations
           promises[reflexId].completedOperations = 0

--- a/lib/stimulus_reflex/broadcasters/broadcaster.rb
+++ b/lib/stimulus_reflex/broadcasters/broadcaster.rb
@@ -29,6 +29,7 @@ module StimulusReflex
       cable_ready[stream_name].dispatch_event(
         name: "stimulus-reflex:server-message",
         detail: {
+          reflexId: data["reflexId"],
           stimulus_reflex: data.merge(
             broadcaster: to_sym,
             server_message: {subject: subject, body: body}

--- a/lib/stimulus_reflex/broadcasters/page_broadcaster.rb
+++ b/lib/stimulus_reflex/broadcasters/page_broadcaster.rb
@@ -18,7 +18,6 @@ module StimulusReflex
           children_only: true,
           permanent_attribute_name: permanent_attribute_name,
           stimulus_reflex: data.merge({
-            last: selector == selectors.last,
             broadast_type: to_sym
           })
         )

--- a/lib/stimulus_reflex/broadcasters/selector_broadcaster.rb
+++ b/lib/stimulus_reflex/broadcasters/selector_broadcaster.rb
@@ -7,7 +7,6 @@ module StimulusReflex
         selectors, html = morph
         updates = selectors.is_a?(Hash) ? selectors : Hash[selectors, html]
         updates.each do |selector, html|
-          last = morph == morphs.last && selector == updates.keys.last
           html = html.to_s
           fragment = Nokogiri::HTML.fragment(html)
           match = fragment.at_css(selector)
@@ -18,7 +17,6 @@ module StimulusReflex
               children_only: true,
               permanent_attribute_name: permanent_attribute_name,
               stimulus_reflex: data.merge({
-                last: last,
                 broadast_type: to_sym
               })
             )
@@ -27,7 +25,6 @@ module StimulusReflex
               selector: selector,
               html: fragment.to_html,
               stimulus_reflex: data.merge({
-                last: last,
                 broadast_type: to_sym
               })
             )


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bug fix

## Description

This PR tackles the issue of afterReflex callbacks firing before CableReady operations can be completed, as well as some other housekeeping concerns.

When we added `data-reflex-root` support to SR, we introduced the `last` flag to the CableReady payload. This was always brittle and should have been removed when we added `reflexId` as a concept. Instead, we had many users reporting intermittent issues with their afterReflex callbacks either not firing, or firing but not seeing visual evidence. This is because each morphdom process takes several ms. The fix introduced in #286 was unfortunately ineffective as a remedy.

I introduced the concept of attaching `totalOperations` and `completedOperations` to the promise tracking the Reflex, and removed the `last` flag entirely as it is no longer required. Each time CableReady finishes an operation, the `completedOperations` count is increased until all have been accounted for, and the callbacks are executed.

I also made sure that the callback events, promises and functions all receive `reflexId`. You can access the `reflexId` of an unresolved promise by accessing `promise.reflexId`, which is pretty fun. Developers can now confidently track the status of reflex operations as uniquely identified transactions. The reflexId is the new last argument of every function. Developers might need to specify an unused `error` argument placeholder in their event handlers to access the `reflexId`; this is not a breaking change because arity was not changed.

As part of this update, I modified the `createSubscription` function to be aware of both `morph` and `innerHtml` functions, as per changes in the `SelectorBroadcaster` class.

Finally, I removed the unused `morphMode` key from the promise response.

Fixes #281

## Why should this be added

This should unblock v3.3 for final review and testing.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
