### PR TITLE
Update morph-modes.md

### DIFF
--- a/docs/morph-modes.md
+++ b/docs/morph-modes.md
@@ -49,7 +49,7 @@ Simply pass a comma-delimited list of CSS selectors. Each selector will retrieve
 StimulusReflex will decide which element's children to replace by evaluating three criteria in order:
 
 1. Is there a `data-reflex-root` on the element with the `data-reflex`?
-2. Is there a `data-reflex-root` on an ancestor element with a `data-controller` above the element in the DOM? It could be the element's immediate parent, but it doesn't have to be.
+2. Is there a `data-reflex-root` on an ancestor element above the element in the DOM? It could be the element's immediate parent, but it doesn't have to be.
 3. Just use the `body` element.
 
 Here is a simple example: the user is presented with a text box. Anything they type into the text box will be echoed back in two div elements, forwards and backwards.
@@ -57,7 +57,7 @@ Here is a simple example: the user is presented with a text box. Anything they t
 {% tabs %}
 {% tab title="index.html.erb" %}
 ```text
-<div data-controller="example" data-reflex-root="[forward],[backward]">
+<div data-reflex-root="[forward],[backward]">
   <input type="text" value="<%= @words %>" data-reflex="keyup->Example#words">
   <div forward><%= @words %></div>
   <div backward><%= @words&.reverse %></div>


### PR DESCRIPTION
Update docs to remove requirement for data-controller on data-reflex-root target

https://github.com/hopsoft/stimulus_reflex/blob/72b185feb956d1bcd07e5d5cffeb7e0216a711c2/javascript/stimulus_reflex.js#L323 does not suggest controller is required

# Type of PR (feature, enhancement, bug fix, etc.)
docs fix
## Description
remove requirement from docs that a data-controller is required

## Why should this be added
The less requirements for adding a data-reflex-root to an element the better imo

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
