### PR TITLE
add redis to cable.yml in development mode

### DIFF
--- a/lib/tasks/stimulus_reflex/install.rake
+++ b/lib/tasks/stimulus_reflex/install.rake
@@ -50,6 +50,16 @@ namespace :stimulus_reflex do
       File.open(filepath, "w") { |f| f.write lines.join }
     end
 
+    filepath = Rails.root.join("config/cable.yml")
+    lines = File.open(filepath, "r") { |f| f.readlines }
+    if lines[1].include?("adapter: async")
+      lines.delete_at 1
+      lines.insert 1, "  adapter: redis\n"
+      lines.insert 2, "  url: <%= ENV.fetch(\"REDIS_URL\") { \"redis://localhost:6379/1\" } %>\n"
+      lines.insert 3, "  channel_prefix: " + Rails.application.class.module_parent.to_s.underscore + "_development\n"
+      File.open(filepath, "w") { |f| f.write lines.join }
+    end
+
     system "bundle exec rails generate stimulus_reflex example"
     system "rails dev:cache" unless Rails.root.join("tmp", "caching-dev.txt").exist?
   end


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Enhancement

## Description

Update install task to change `adapter: async` to a Redis config in `cable.yml` for the development environment

## Why should this be added

SR works best when Redis is backing ActionCable

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
