### PR TITLE
ActionCable connectivity events

### DIFF
--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -34,16 +34,6 @@ const promises = {}
 // Indicates if we should log calls to stimulate, etc...
 let debugging = false
 
-const emitEvent = (event, detail) => {
-  document.dispatchEvent(
-    new CustomEvent(event, {
-      bubbles: true,
-      cancelable: false,
-      detail
-    })
-  )
-}
-
 // Subscribes a StimulusReflex controller to an ActionCable channel.
 // controller - the StimulusReflex controller to subscribe
 //
@@ -53,6 +43,16 @@ const createSubscription = controller => {
   const identifier = JSON.stringify({ channel })
   let totalOperations
   let reflexId
+
+  const emitEvent = (event, detail) => {
+    document.dispatchEvent(
+      new CustomEvent(event, {
+        bubbles: true,
+        cancelable: false,
+        detail
+      })
+    )
+  }
 
   controller.StimulusReflex.subscription =
     actionCableConsumer.subscriptions.findAll(identifier)[0] ||


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Enhancement

## Description

Introduces events based on ActionCable channel subscription status. Events are fired on **document**.

- `stimulus-reflex:connected`
- `stimulus-reflex:rejected`
- `stimulus-reflex:disconnected`

Pulls much of the client-side code from #243 which is currently pending until after v3.3 is released.

`stimulus-reflex:disconnected` populates the `detail` object with the boolean key `willAttemptReconnect` which is tied to ActionCable's capacity to reconnect when disconnected.

## Why should this be added

Useful for testing and building UIs that can verify SR is ready before calling `stimulate`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
