### PR TITLE
Print warning and exit if caching is disabled or npm/gem versions are mismatched

### DIFF
--- a/lib/stimulus_reflex.rb
+++ b/lib/stimulus_reflex.rb
@@ -20,12 +20,12 @@ require "generators/stimulus_reflex_generator"
 
 module StimulusReflex
   class Engine < Rails::Engine
-    initializer "verify_caching" do
+    initializer "stimulus_reflex.verify_caching_enabled" do
       unless caching_enabled?
         puts <<~WARN
           Stimulus Reflex requires caching to be enabled. Caching allows the session to be modified during ActionCable requests.
           To enable caching in development, run:
-          
+
             rails dev:cache
         WARN
         exit

--- a/lib/stimulus_reflex.rb
+++ b/lib/stimulus_reflex.rb
@@ -22,11 +22,11 @@ module StimulusReflex
   class Engine < Rails::Engine
     initializer "verify_caching" do
       unless caching_enabled?
-        puts <<-WARN
-Stimulus Reflex requires caching to be enabled. Caching allows the session to be modified during ActionCable requests.
-To enable caching in development, run:
-
-  rails dev:cache
+        puts <<~WARN
+          Stimulus Reflex requires caching to be enabled. Caching allows the session to be modified during ActionCable requests.
+          To enable caching in development, run:
+          
+            rails dev:cache
         WARN
         exit
       end

--- a/lib/stimulus_reflex.rb
+++ b/lib/stimulus_reflex.rb
@@ -20,6 +20,8 @@ require "generators/stimulus_reflex_generator"
 
 module StimulusReflex
   class Engine < Rails::Engine
+    NODE_VERSION_FORMAT = /(\d\.\d\.\d.*):/
+
     initializer "stimulus_reflex.verify_caching_enabled" do
       unless caching_enabled?
         puts <<~WARN
@@ -32,10 +34,39 @@ module StimulusReflex
       end
     end
 
+    initializer "stimulus_reflex.verify_npm_package_version" do
+      unless node_version_matches?
+        puts <<~WARN
+          The Stimulus Reflex javascript package version (#{node_package_version}) does not match the Rubygem version (#{gem_version}).
+          To update the Stimulus Reflex node module:
+
+            yarn upgrade stimulus_reflex@#{gem_version}
+        WARN
+        exit
+      end
+    end
+
     private
 
     def caching_enabled?
-      Rails.application.config.action_controller.perform_caching
+      Rails.application.config.action_controller.perform_caching &&
+        Rails.application.config.cache_store != :null_store
+    end
+
+    def node_version_matches?
+      node_package_version == gem_version
+    end
+
+    def gem_version
+      StimulusReflex::VERSION.gsub(".pre", "-pre")
+    end
+
+    def node_package_version
+      File.foreach(yarn_lock_path).grep(/^stimulus_reflex/).first[NODE_VERSION_FORMAT, 1]
+    end
+
+    def yarn_lock_path
+      Rails.root.join("yarn.lock")
     end
   end
 end

--- a/lib/stimulus_reflex.rb
+++ b/lib/stimulus_reflex.rb
@@ -20,5 +20,22 @@ require "generators/stimulus_reflex_generator"
 
 module StimulusReflex
   class Engine < Rails::Engine
+    initializer "verify_caching" do
+      unless caching_enabled?
+        puts <<-WARN
+Stimulus Reflex requires caching to be enabled. Caching allows the session to be modified during ActionCable requests.
+To enable caching in development, run:
+
+  rails dev:cache
+        WARN
+        exit
+      end
+    end
+
+    private
+
+    def caching_enabled?
+      Rails.application.config.action_controller.perform_caching
+    end
   end
 end


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Fix 

## Description

As stated in #258, caching being required trips up a lot of people. Typically, they'll see a seemingly random `InvalidAuthenticityToken` and no idea that it was related to the Stimulus Reflex requirements around caching. Usually they see this trying to login or sign up in their apps and find they get this error instead.

I've gotten a bunch of questions about this from Jumpstart Pro users who want to use Stimulus Reflex and run into this problem and it leads to a lot of confusion.

Fixes #258

This also addresses the other half of #297 and will verify the NPM package version matches the Rubygem version on boot. 👍 

## Why should this be added

This configures an initializer to verify that caching is enabled. If not, it will print a message and exit if caching is disabled. Same goes for mismatched client and server versions.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing