### PR TITLE
Support IE11 msCrypto (#308)

### DIFF
--- a/javascript/utils.js
+++ b/javascript/utils.js
@@ -1,6 +1,7 @@
 // uuid4 function taken from stackoverflow
 // https://stackoverflow.com/a/2117523/554903
 export const uuidv4 = () => {
+  const crypto = window.crypto || window.msCrypto
   return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, c =>
     (
       c ^


### PR DESCRIPTION
# IE11 Browser Support

## Description

To use the crypto object in Internet Explorer 11 we need to call it with a different name (msCrypto instead of crypto).
Described in: https://developer.mozilla.org/en-US/docs/Web/API/Window/crypto

Fixes #308

## Why should this be added

IE11 Support

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
