### PR TITLE
Refactor sanity checks on boot

### DIFF
--- a/lib/stimulus_reflex.rb
+++ b/lib/stimulus_reflex.rb
@@ -12,6 +12,7 @@ require "stimulus_reflex/version"
 require "stimulus_reflex/reflex"
 require "stimulus_reflex/element"
 require "stimulus_reflex/channel"
+require "stimulus_reflex/sanity_checker"
 require "stimulus_reflex/broadcasters/broadcaster"
 require "stimulus_reflex/broadcasters/nothing_broadcaster"
 require "stimulus_reflex/broadcasters/page_broadcaster"
@@ -20,68 +21,9 @@ require "generators/stimulus_reflex_generator"
 
 module StimulusReflex
   class Engine < Rails::Engine
-    NODE_VERSION_FORMAT = /(\d\.\d\.\d.*):/
-    JSON_VERSION_FORMAT = /(\d\.\d\.\d.*)"/
-
-    initializer "stimulus_reflex.verify_caching_enabled" do
-      unless caching_enabled?
-        puts <<~WARN
-          Stimulus Reflex requires caching to be enabled. Caching allows the session to be modified during ActionCable requests.
-          To enable caching in development, run:
-
-            rails dev:cache
-        WARN
-        exit
-      end
-    end
-
-    initializer "stimulus_reflex.verify_npm_package_version" do
-      unless node_version_matches?
-        puts <<~WARN
-          The Stimulus Reflex javascript package version (#{node_package_version}) does not match the Rubygem version (#{gem_version}).
-          To update the Stimulus Reflex node module:
-
-            yarn upgrade stimulus_reflex@#{gem_version}
-        WARN
-        exit
-      end
-    end
-
-    private
-
-    def caching_enabled?
-      Rails.application.config.action_controller.perform_caching &&
-        Rails.application.config.cache_store != :null_store
-    end
-
-    def node_version_matches?
-      node_package_version == gem_version
-    end
-
-    def gem_version
-      StimulusReflex::VERSION.gsub(".pre", "-pre")
-    end
-
-    def node_package_version
-      match = File.foreach(yarn_lock_path).grep(/^stimulus_reflex/)
-      return match.first[NODE_VERSION_FORMAT, 1] if match.present?
-
-      match = File.foreach(yarn_link_path).grep(/version/)
-      return match.first[JSON_VERSION_FORMAT, 1] if match.present?
-
-      puts <<~WARN
-        Can't locate the stimulus_reflex NPM package. 
-        Either add it to your package.json as a dependency or use "yarn link stimulus_reflex" if you are doing development.
-      WARN
-      exit
-    end
-
-    def yarn_lock_path
-      Rails.root.join("yarn.lock")
-    end
-
-    def yarn_link_path
-      Rails.root.join("node_modules", "stimulus_reflex", "package.json")
+    initializer "stimulus_reflex.sanity_check" do
+      SanityChecker.check_caching_enabled
+      SanityChecker.check_javascript_package_version
     end
   end
 end

--- a/lib/stimulus_reflex.rb
+++ b/lib/stimulus_reflex.rb
@@ -22,8 +22,7 @@ require "generators/stimulus_reflex_generator"
 module StimulusReflex
   class Engine < Rails::Engine
     initializer "stimulus_reflex.sanity_check" do
-      SanityChecker.check_caching_enabled
-      SanityChecker.check_javascript_package_version
+      SanityChecker.check!
     end
   end
 end

--- a/lib/stimulus_reflex/sanity_checker.rb
+++ b/lib/stimulus_reflex/sanity_checker.rb
@@ -6,10 +6,9 @@ module SanityChecker
     def check_caching_enabled
       unless caching_enabled?
         puts <<~WARN
-          Stimulus Reflex requires caching to be enabled. Caching allows the session to be modified during ActionCable requests.
+          WARNING: Stimulus Reflex requires caching to be enabled. Caching allows the session to be modified during ActionCable requests.
           To enable caching in development, run:
-
-            rails dev:cache
+              rails dev:cache
         WARN
       end
     end
@@ -17,17 +16,16 @@ module SanityChecker
     def check_javascript_package_version
       if javascript_package_version.nil?
         puts <<~WARN
-          Can't locate the stimulus_reflex NPM package.
+          WARNING: Can't locate the stimulus_reflex NPM package.
           Either add it to your package.json as a dependency or use "yarn link stimulus_reflex" if you are doing development.
         WARN
       end
 
       unless javascript_version_matches?
         puts <<~WARN
-          The Stimulus Reflex javascript package version (#{javascript_package_version}) does not match the Rubygem version (#{gem_version}).
+          WARNING: The Stimulus Reflex javascript package version (#{javascript_package_version}) does not match the Rubygem version (#{gem_version}).
           To update the Stimulus Reflex npm package:
-
-            yarn upgrade stimulus_reflex@#{gem_version}
+              yarn upgrade stimulus_reflex@#{gem_version}
         WARN
       end
     end
@@ -44,19 +42,25 @@ module SanityChecker
     end
 
     def gem_version
-      StimulusReflex::VERSION.gsub(".pre", "-pre")
+      @_gem_version ||= StimulusReflex::VERSION.gsub(".pre", "-pre")
     end
 
     def javascript_package_version
-      if File.exist?(yarn_lock_path)
-        match = File.foreach(yarn_lock_path).grep(/^stimulus_reflex/)
-        return match.first[NODE_VERSION_FORMAT, 1] if match.present?
-      end
+      return @_js_version if defined?(@_js_version)
+      @_js_version = find_javascript_package_version
+    end
 
-      if File.exist?(yarn_link_path)
-        match = File.foreach(yarn_link_path).grep(/version/)
-        return match.first[JSON_VERSION_FORMAT, 1] if match.present?
+    def find_javascript_package_version
+      if (match = search_file(yarn_lock_path, regex: /^stimulus_reflex/))
+        match[NODE_VERSION_FORMAT, 1]
+      elsif (match = search_file(yarn_link_path, regex: /version/))
+        match[JSON_VERSION_FORMAT, 1]
       end
+    end
+
+    def search_file(path, regex:)
+      return unless File.exist?(path)
+      File.foreach(path).grep(regex).first
     end
 
     def yarn_lock_path

--- a/lib/stimulus_reflex/sanity_checker.rb
+++ b/lib/stimulus_reflex/sanity_checker.rb
@@ -1,8 +1,14 @@
-module SanityChecker
-  NODE_VERSION_FORMAT = /(\d+\.\d+\.\d+.*):/
-  JSON_VERSION_FORMAT = /(\d+\.\d+\.\d+.*)"/
+module StimulusReflex
+  class SanityChecker
+    NODE_VERSION_FORMAT = /(\d+\.\d+\.\d+.*):/
+    JSON_VERSION_FORMAT = /(\d+\.\d+\.\d+.*)"/
 
-  class << self
+    def self.check!
+      instance = new
+      instance.check_caching_enabled
+      instance.check_javascript_package_version
+    end
+
     def check_caching_enabled
       unless caching_enabled?
         puts <<~WARN

--- a/lib/stimulus_reflex/sanity_checker.rb
+++ b/lib/stimulus_reflex/sanity_checker.rb
@@ -1,80 +1,80 @@
-module StimulusReflex
-  class SanityChecker
-    NODE_VERSION_FORMAT = /(\d+\.\d+\.\d+.*):/
-    JSON_VERSION_FORMAT = /(\d+\.\d+\.\d+.*)"/
+# frozen_string_literal: true
 
-    def self.check!
-      instance = new
-      instance.check_caching_enabled
-      instance.check_javascript_package_version
+class StimulusReflex::SanityChecker
+  NODE_VERSION_FORMAT = /(\d+\.\d+\.\d+.*):/
+  JSON_VERSION_FORMAT = /(\d+\.\d+\.\d+.*)"/
+
+  def self.check!
+    instance = new
+    instance.check_caching_enabled
+    instance.check_javascript_package_version
+  end
+
+  def check_caching_enabled
+    unless caching_enabled?
+      puts <<~WARN
+        WARNING: Stimulus Reflex requires caching to be enabled. Caching allows the session to be modified during ActionCable requests.
+        To enable caching in development, run:
+            rails dev:cache
+      WARN
+    end
+  end
+
+  def check_javascript_package_version
+    if javascript_package_version.nil?
+      puts <<~WARN
+        WARNING: Can't locate the stimulus_reflex NPM package.
+        Either add it to your package.json as a dependency or use "yarn link stimulus_reflex" if you are doing development.
+      WARN
     end
 
-    def check_caching_enabled
-      unless caching_enabled?
-        puts <<~WARN
-          WARNING: Stimulus Reflex requires caching to be enabled. Caching allows the session to be modified during ActionCable requests.
-          To enable caching in development, run:
-              rails dev:cache
-        WARN
-      end
+    unless javascript_version_matches?
+      puts <<~WARN
+        WARNING: The Stimulus Reflex javascript package version (#{javascript_package_version}) does not match the Rubygem version (#{gem_version}).
+        To update the Stimulus Reflex npm package:
+            yarn upgrade stimulus_reflex@#{gem_version}
+      WARN
     end
+  end
 
-    def check_javascript_package_version
-      if javascript_package_version.nil?
-        puts <<~WARN
-          WARNING: Can't locate the stimulus_reflex NPM package.
-          Either add it to your package.json as a dependency or use "yarn link stimulus_reflex" if you are doing development.
-        WARN
-      end
+  private
 
-      unless javascript_version_matches?
-        puts <<~WARN
-          WARNING: The Stimulus Reflex javascript package version (#{javascript_package_version}) does not match the Rubygem version (#{gem_version}).
-          To update the Stimulus Reflex npm package:
-              yarn upgrade stimulus_reflex@#{gem_version}
-        WARN
-      end
+  def caching_enabled?
+    Rails.application.config.action_controller.perform_caching &&
+      Rails.application.config.cache_store != :null_store
+  end
+
+  def javascript_version_matches?
+    javascript_package_version == gem_version
+  end
+
+  def gem_version
+    @_gem_version ||= StimulusReflex::VERSION.gsub(".pre", "-pre")
+  end
+
+  def javascript_package_version
+    return @_js_version if defined?(@_js_version)
+    @_js_version = find_javascript_package_version
+  end
+
+  def find_javascript_package_version
+    if (match = search_file(yarn_lock_path, regex: /^stimulus_reflex/))
+      match[NODE_VERSION_FORMAT, 1]
+    elsif (match = search_file(yarn_link_path, regex: /version/))
+      match[JSON_VERSION_FORMAT, 1]
     end
+  end
 
-    private
+  def search_file(path, regex:)
+    return unless File.exist?(path)
+    File.foreach(path).grep(regex).first
+  end
 
-    def caching_enabled?
-      Rails.application.config.action_controller.perform_caching &&
-        Rails.application.config.cache_store != :null_store
-    end
+  def yarn_lock_path
+    Rails.root.join("yarn.lock")
+  end
 
-    def javascript_version_matches?
-      javascript_package_version == gem_version
-    end
-
-    def gem_version
-      @_gem_version ||= StimulusReflex::VERSION.gsub(".pre", "-pre")
-    end
-
-    def javascript_package_version
-      return @_js_version if defined?(@_js_version)
-      @_js_version = find_javascript_package_version
-    end
-
-    def find_javascript_package_version
-      if (match = search_file(yarn_lock_path, regex: /^stimulus_reflex/))
-        match[NODE_VERSION_FORMAT, 1]
-      elsif (match = search_file(yarn_link_path, regex: /version/))
-        match[JSON_VERSION_FORMAT, 1]
-      end
-    end
-
-    def search_file(path, regex:)
-      return unless File.exist?(path)
-      File.foreach(path).grep(regex).first
-    end
-
-    def yarn_lock_path
-      Rails.root.join("yarn.lock")
-    end
-
-    def yarn_link_path
-      Rails.root.join("node_modules", "stimulus_reflex", "package.json")
-    end
+  def yarn_link_path
+    Rails.root.join("node_modules", "stimulus_reflex", "package.json")
   end
 end

--- a/lib/stimulus_reflex/sanity_checker.rb
+++ b/lib/stimulus_reflex/sanity_checker.rb
@@ -1,0 +1,70 @@
+module SanityChecker
+  NODE_VERSION_FORMAT = /(\d+\.\d+\.\d+.*):/
+  JSON_VERSION_FORMAT = /(\d+\.\d+\.\d+.*)"/
+
+  class << self
+    def check_caching_enabled
+      unless caching_enabled?
+        puts <<~WARN
+          Stimulus Reflex requires caching to be enabled. Caching allows the session to be modified during ActionCable requests.
+          To enable caching in development, run:
+
+            rails dev:cache
+        WARN
+      end
+    end
+
+    def check_javascript_package_version
+      if javascript_package_version.nil?
+        puts <<~WARN
+          Can't locate the stimulus_reflex NPM package.
+          Either add it to your package.json as a dependency or use "yarn link stimulus_reflex" if you are doing development.
+        WARN
+      end
+
+      unless javascript_version_matches?
+        puts <<~WARN
+          The Stimulus Reflex javascript package version (#{javascript_package_version}) does not match the Rubygem version (#{gem_version}).
+          To update the Stimulus Reflex npm package:
+
+            yarn upgrade stimulus_reflex@#{gem_version}
+        WARN
+      end
+    end
+
+    private
+
+    def caching_enabled?
+      Rails.application.config.action_controller.perform_caching &&
+        Rails.application.config.cache_store != :null_store
+    end
+
+    def javascript_version_matches?
+      javascript_package_version == gem_version
+    end
+
+    def gem_version
+      StimulusReflex::VERSION.gsub(".pre", "-pre")
+    end
+
+    def javascript_package_version
+      if File.exist?(yarn_lock_path)
+        match = File.foreach(yarn_lock_path).grep(/^stimulus_reflex/)
+        return match.first[NODE_VERSION_FORMAT, 1] if match.present?
+      end
+
+      if File.exist?(yarn_link_path)
+        match = File.foreach(yarn_link_path).grep(/version/)
+        return match.first[JSON_VERSION_FORMAT, 1] if match.present?
+      end
+    end
+
+    def yarn_lock_path
+      Rails.root.join("yarn.lock")
+    end
+
+    def yarn_link_path
+      Rails.root.join("node_modules", "stimulus_reflex", "package.json")
+    end
+  end
+end


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bug fix

## Description

Cleaned up and refactored the sanity checker into a class that's run in an initializer and changed a few things:

* No longer exit, just print warnings. Exiting is too heavy handed.
* Check if yarn.lock and package.json exist before reading them.
* Move warning when NPM version can't be found.
* Memoize versions after lookup so we're not reading files multiple times.
* Fix version match to support multiple digits for each part (i.e. `3.10.11`)

## Why should this be added

Bug fixes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
