### PR TITLE
add ready event after setupDeclarativeReflexes

### DIFF
--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -5,7 +5,7 @@ import { defaultSchema } from './schema'
 import { getConsumer } from './consumer'
 import { dispatchLifecycleEvent } from './lifecycle'
 import { allReflexControllers } from './controllers'
-import { uuidv4, debounce } from './utils'
+import { uuidv4, debounce, emitEvent } from './utils'
 import Log from './log'
 import {
   attributeValue,
@@ -43,16 +43,6 @@ const createSubscription = controller => {
   const identifier = JSON.stringify({ channel })
   let totalOperations
   let reflexId
-
-  const emitEvent = (event, detail) => {
-    document.dispatchEvent(
-      new CustomEvent(event, {
-        bubbles: true,
-        cancelable: false,
-        detail
-      })
-    )
-  }
 
   controller.StimulusReflex.subscription =
     actionCableConsumer.subscriptions.findAll(identifier)[0] ||
@@ -321,6 +311,7 @@ const setupDeclarativeReflexes = debounce(() => {
           actionValue
         )
     })
+  emitEvent('stimulus-reflex:ready')
 }, 20)
 
 // Given a reflex string such as 'click->TestReflex#create' and a list of

--- a/javascript/utils.js
+++ b/javascript/utils.js
@@ -39,3 +39,13 @@ export const extractReflexName = reflexString => {
 
   return match ? match[1] : ''
 }
+
+export const emitEvent = (event, detail) => {
+  document.dispatchEvent(
+    new CustomEvent(event, {
+      bubbles: true,
+      cancelable: false,
+      detail
+    })
+  )
+}


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Enhancement

## Description

Moves `emitEvent` into `utils.js` and adds a `stimulus-reflex:ready` event which fires each time the `setupDeclarativeReflexes` function finishes.

## Why should this be added

This feature was requested by @scottbarrow to aid in configuring Cypress test runners needing to wait until SR is ready for automated button clicking to begin. The alternative was a hard-coded delay which is slow and unreliable.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
