### PR TITLE
fixes and tweaks to client logging subsystem

### DIFF
--- a/javascript/log.js
+++ b/javascript/log.js
@@ -18,17 +18,15 @@ function request (
 
 function success (response, options = { halted: false }) {
   const { event } = response
-  const { reflexId, target, last, broadcaster, updates } =
-    event.detail.stimulusReflex || {}
+  const { reflexId, target, broadcaster } = event.detail.stimulusReflex || {}
 
   console.log(`\u2193 reflex \u2193 ${target}`, {
     reflexId,
     duration: `${new Date() - logs[reflexId]}ms`,
     halted: options.halted,
-    broadcaster,
-    updates
+    broadcaster
   })
-  if (last) delete logs[reflexId]
+  delete logs[reflexId]
 }
 
 function error (response) {

--- a/lib/stimulus_reflex/broadcasters/page_broadcaster.rb
+++ b/lib/stimulus_reflex/broadcasters/page_broadcaster.rb
@@ -18,7 +18,7 @@ module StimulusReflex
           children_only: true,
           permanent_attribute_name: permanent_attribute_name,
           stimulus_reflex: data.merge({
-            broadast_type: to_sym
+            broadcaster: to_sym
           })
         )
       end

--- a/lib/stimulus_reflex/broadcasters/selector_broadcaster.rb
+++ b/lib/stimulus_reflex/broadcasters/selector_broadcaster.rb
@@ -17,7 +17,7 @@ module StimulusReflex
               children_only: true,
               permanent_attribute_name: permanent_attribute_name,
               stimulus_reflex: data.merge({
-                broadast_type: to_sym
+                broadcaster: to_sym
               })
             )
           else
@@ -25,7 +25,7 @@ module StimulusReflex
               selector: selector,
               html: fragment.to_html,
               stimulus_reflex: data.merge({
-                broadast_type: to_sym
+                broadcaster: to_sym
               })
             )
           end


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bug fix

## Description

There were three copies of the same typo in the broadcaster classes, preventing client logging from displaying the morph mode broadcaster type. I also removed the `last` and `updates` keys from the `log.js` because they are no longer concepts in this framework.

## Why should this be added

Client logging now shows correct broadcaster type and this would make anyone happy.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
