### PR TITLE
lifecycle refactor: introduce new finalize stage, global reflexes dictionary

### DIFF
--- a/javascript/log.js
+++ b/javascript/log.js
@@ -49,6 +49,7 @@ function error (response) {
       `\u2193 reflex \u2193 ${target}`,
       detail.stimulusReflex.serverMessage.body
     )
+  delete logs[reflexId]
 }
 
 export default {

--- a/javascript/log.js
+++ b/javascript/log.js
@@ -1,17 +1,11 @@
 const logs = {}
 
-function request (
-  reflexId,
-  target,
-  args,
-  stimulusControllerIdentifier,
-  element
-) {
+function request (reflexId, target, args, controller, element) {
   logs[reflexId] = new Date()
   console.log(`\u2191 stimulus \u2191 ${target}`, {
     reflexId,
     args,
-    stimulusControllerIdentifier,
+    controller,
     element
   })
 }
@@ -20,31 +14,42 @@ function success (event, options = { halted: false }) {
   const { detail } = event || {}
   const { selector } = detail || {}
   const { reflexId, target, morph } = event.detail.stimulusReflex || {}
-  const progress = options.completed
-    ? ` ${options.completed}/${options.total}`
-    : ''
+  const progress =
+    options.completed && options.total > 1
+      ? ` ${options.completed}/${options.total}`
+      : ''
+  const duration = `${new Date() - logs[reflexId]}ms`
+  const operation = event.type
+    .split(':')[1]
+    .split('-')
+    .slice(1)
+    .join('_')
 
-  console.log(`\u2193 reflex \u2193 ${target}${progress}`, {
-    reflexId,
-    duration: `${new Date() - logs[reflexId]}ms`,
-    halted: options.halted,
-    morph,
-    selector
-  })
+  console.log(
+    `\u2193 reflex \u2193 ${target} \u2192 ${selector}${progress} in ${duration}`,
+    {
+      reflexId,
+      morph,
+      operation,
+      halted: options.halted
+    }
+  )
 }
 
 function error (event) {
   const { detail } = event || {}
   const { selector } = detail || {}
   const { reflexId, target, error, morph } = detail.stimulusReflex || {}
-  console.error(`\u2193 reflex \u2193 ${target}`, {
-    reflexId,
-    duration: `${new Date() - logs[reflexId]}ms`,
-    error,
-    morph,
-    payload: event.detail.stimulusReflex,
-    selector
-  })
+  const duration = `${new Date() - logs[reflexId]}ms`
+  console.error(
+    `\u2193 reflex \u2193 ${target} \u2192 ${selector} in ${duration}`,
+    {
+      reflexId,
+      error,
+      morph,
+      payload: event.detail.stimulusReflex
+    }
+  )
   if (detail.stimulusReflex.serverMessage.body)
     console.error(
       `\u2193 reflex \u2193 ${target}`,

--- a/javascript/log.js
+++ b/javascript/log.js
@@ -24,7 +24,6 @@ function success (event, options) {
     .split('-')
     .slice(1)
     .join('_')
-
   console.log(
     `\u2193 reflex \u2193 ${target} \u2192 ${selector ||
       '\u221E'}${progress} in ${duration}`,
@@ -39,24 +38,16 @@ function success (event, options) {
 
 function error (event) {
   const { detail } = event || {}
-  const { selector } = detail || {}
-  const { reflexId, target, error, morph } = detail.stimulusReflex || {}
+  const { reflexId, target } = detail.stimulusReflex || {}
   const duration = `${new Date() - logs[reflexId]}ms`
-  console.error(
-    `\u2193 reflex \u2193 ${target} \u2192 ${selector ||
-      '\u221E'} in ${duration}`,
+  console.log(
+    `\u2193 reflex \u2193 ${target} in ${duration} %cERROR: ${detail.stimulusReflex.serverMessage.body}`,
+    'color: #f00;',
     {
       reflexId,
-      error,
-      morph,
       payload: event.detail.stimulusReflex
     }
   )
-  if (detail.stimulusReflex.serverMessage.body)
-    console.error(
-      `\u2193 reflex \u2193 ${target}`,
-      detail.stimulusReflex.serverMessage.body
-    )
 }
 
 export default {

--- a/javascript/log.js
+++ b/javascript/log.js
@@ -16,31 +16,32 @@ function request (
   })
 }
 
-function success (response, options = { halted: false }) {
-  const { event } = response
+function success (event, options = { halted: false }) {
   const { detail } = event || {}
   const { selector } = detail || {}
-  const { reflexId, target, broadcaster } = event.detail.stimulusReflex || {}
+  const { reflexId, target, morph } = event.detail.stimulusReflex || {}
+  const progress = options.completed
+    ? ` ${options.completed}/${options.total}`
+    : ''
 
-  console.log(`\u2193 reflex \u2193 ${target}`, {
+  console.log(`\u2193 reflex \u2193 ${target}${progress}`, {
     reflexId,
     duration: `${new Date() - logs[reflexId]}ms`,
     halted: options.halted,
-    broadcaster,
+    morph,
     selector
   })
 }
 
-function error (response) {
-  const { event } = response || {}
+function error (event) {
   const { detail } = event || {}
   const { selector } = detail || {}
-  const { reflexId, target, error, broadcaster } = detail.stimulusReflex || {}
+  const { reflexId, target, error, morph } = detail.stimulusReflex || {}
   console.error(`\u2193 reflex \u2193 ${target}`, {
     reflexId,
     duration: `${new Date() - logs[reflexId]}ms`,
     error,
-    broadcaster,
+    morph,
     payload: event.detail.stimulusReflex,
     selector
   })

--- a/javascript/log.js
+++ b/javascript/log.js
@@ -10,7 +10,7 @@ function request (reflexId, target, args, controller, element) {
   })
 }
 
-function success (event, options = { halted: false }) {
+function success (event, options) {
   const { detail } = event || {}
   const { selector } = detail || {}
   const { reflexId, target, morph } = event.detail.stimulusReflex || {}
@@ -26,7 +26,8 @@ function success (event, options = { halted: false }) {
     .join('_')
 
   console.log(
-    `\u2193 reflex \u2193 ${target} \u2192 ${selector}${progress} in ${duration}`,
+    `\u2193 reflex \u2193 ${target} \u2192 ${selector ||
+      '\u221E'}${progress} in ${duration}`,
     {
       reflexId,
       morph,
@@ -42,7 +43,8 @@ function error (event) {
   const { reflexId, target, error, morph } = detail.stimulusReflex || {}
   const duration = `${new Date() - logs[reflexId]}ms`
   console.error(
-    `\u2193 reflex \u2193 ${target} \u2192 ${selector} in ${duration}`,
+    `\u2193 reflex \u2193 ${target} \u2192 ${selector ||
+      '\u221E'} in ${duration}`,
     {
       reflexId,
       error,
@@ -55,7 +57,6 @@ function error (event) {
       `\u2193 reflex \u2193 ${target}`,
       detail.stimulusReflex.serverMessage.body
     )
-  delete logs[reflexId]
 }
 
 export default {

--- a/javascript/log.js
+++ b/javascript/log.js
@@ -18,20 +18,23 @@ function request (
 
 function success (response, options = { halted: false }) {
   const { event } = response
+  const { detail } = event || {}
+  const { selector } = detail || {}
   const { reflexId, target, broadcaster } = event.detail.stimulusReflex || {}
 
   console.log(`\u2193 reflex \u2193 ${target}`, {
     reflexId,
     duration: `${new Date() - logs[reflexId]}ms`,
     halted: options.halted,
-    broadcaster
+    broadcaster,
+    selector
   })
-  delete logs[reflexId]
 }
 
 function error (response) {
-  const { event, element } = response || {}
+  const { event } = response || {}
   const { detail } = event || {}
+  const { selector } = detail || {}
   const { reflexId, target, error, broadcaster } = detail.stimulusReflex || {}
   console.error(`\u2193 reflex \u2193 ${target}`, {
     reflexId,
@@ -39,17 +42,17 @@ function error (response) {
     error,
     broadcaster,
     payload: event.detail.stimulusReflex,
-    element
+    selector
   })
   if (detail.stimulusReflex.serverMessage.body)
     console.error(
       `\u2193 reflex \u2193 ${target}`,
       detail.stimulusReflex.serverMessage.body
     )
-  delete logs[reflexId]
 }
 
 export default {
+  logs,
   request,
   success,
   error

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -273,13 +273,13 @@ const setupDeclarativeReflexes = debounce(() => {
       const controllers = attributeValues(
         element.getAttribute(stimulusApplication.schema.controllerAttribute)
       )
-      const reflexInstances = attributeValues(
+      const reflexAttributeNames = attributeValues(
         element.getAttribute(stimulusApplication.schema.reflexAttribute)
       )
       const actions = attributeValues(
         element.getAttribute(stimulusApplication.schema.actionAttribute)
       )
-      reflexInstances.forEach(reflex => {
+      reflexAttributeNames.forEach(reflex => {
         const controller = findControllerByReflexString(
           reflex,
           allReflexControllers(stimulusApplication, element)

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -413,6 +413,12 @@ if (!document.stimulusReflexInitialized) {
     const promise = promises[reflexId]
 
     promise.completedOperations++
+    if (debugging)
+      Log.success(event, {
+        halted: false,
+        completed: promise.completedOperations,
+        total: promise.totalOperations
+      })
     if (promise.completedOperations < promise.totalOperations) return
 
     const response = {
@@ -427,7 +433,6 @@ if (!document.stimulusReflexInitialized) {
     }
 
     dispatchLifecycleEvent('success', element, reflexId)
-    if (debugging) Log.success(response)
   }
 
   document.addEventListener(
@@ -483,7 +488,8 @@ if (!document.stimulusReflexInitialized) {
           )
         })
       }
-      delete Log.logs[event.detail.stimulusReflex.reflexId]
+      if (!promises[event.detail.stimulusReflex.reflexId])
+        delete Log.logs[event.detail.stimulusReflex.reflexId]
     }
   }
 
@@ -530,19 +536,19 @@ if (!document.stimulusReflexInitialized) {
     if (debugging) {
       switch (subject) {
         case 'error':
-          Log.error(response)
+          Log.error(event)
           break
         case 'selector':
-          Log.success(response)
+          Log.success(event)
           break
         case 'nothing':
-          Log.success(response)
+          Log.success(event)
           break
         case 'halted':
-          Log.success(response, { halted: true })
+          Log.success(event, { halted: true })
           break
         default:
-          Log.success(response)
+          Log.success(event)
           break
       }
     }

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -279,19 +279,19 @@ const setupDeclarativeReflexes = debounce(() => {
       const actions = attributeValues(
         element.getAttribute(stimulusApplication.schema.actionAttribute)
       )
-      reflexAttributeNames.forEach(reflex => {
-        const controller = findControllerByReflexString(
-          reflex,
+      reflexAttributeNames.forEach(reflexName => {
+        const controller = findControllerByReflexName(
+          reflexName,
           allReflexControllers(stimulusApplication, element)
         )
         let action
         if (controller) {
-          action = `${reflex.split('->')[0]}->${
+          action = `${reflexName.split('->')[0]}->${
             controller.identifier
           }#__perform`
           if (!actions.includes(action)) actions.push(action)
         } else {
-          action = `${reflex.split('->')[0]}->stimulus-reflex#__perform`
+          action = `${reflexName.split('->')[0]}->stimulus-reflex#__perform`
           if (!controllers.includes('stimulus-reflex')) {
             controllers.push('stimulus-reflex')
           }
@@ -327,12 +327,12 @@ const setupDeclarativeReflexes = debounce(() => {
 // controllers. It will find the matching controller based on the controller's
 // identifier. e.g. Given these controller identifiers ['foo', 'bar', 'test'],
 // it would select the 'test' controller.
-const findControllerByReflexString = (reflexString, controllers) => {
+const findControllerByReflexName = (reflexName, controllers) => {
   const controller = controllers.find(controller => {
     if (!controller.identifier) return
 
     return (
-      extractReflexName(reflexString).toLowerCase() ===
+      extractReflexName(reflexName).toLowerCase() ===
       controller.identifier.toLowerCase()
     )
   })

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -37,9 +37,6 @@ const promises = {}
 // Indicates if we should log calls to stimulate, etc...
 let debugging = false
 
-// Should we draw pretty boxes when CableReady updates content?
-let wireframes = null
-
 // Subscribes a StimulusReflex controller to an ActionCable channel.
 // controller - the StimulusReflex controller to subscribe
 //
@@ -376,10 +373,9 @@ const getReflexRoots = element => {
 //   * consumer - [optional] the ActionCable consumer
 //
 const initialize = (application, initializeOptions = {}) => {
-  const { controller, consumer, debug, params, gsap } = initializeOptions
+  const { controller, consumer, debug, params } = initializeOptions
   actionCableConsumer = consumer
   actionCableParams = params
-  if (gsap && typeof gsap === 'object') wireframes = gsap
   stimulusApplication = application
   stimulusApplication.schema = { ...defaultSchema, ...application.schema }
   stimulusApplication.register(
@@ -442,55 +438,10 @@ if (!document.stimulusReflexInitialized) {
   document.addEventListener('cable-ready:before-morph', beforeDOMUpdateHandler)
 
   const afterDOMUpdateHandler = event => {
-    if (event.detail.stimulusReflex) {
-      if (wireframes) {
-        const duration =
-          new Date() - Log.logs[event.detail.stimulusReflex.reflexId]
-        const selector = document.querySelector(event.detail.selector)
-        const style = getComputedStyle(selector)
-        const backgroundColor = style.getPropertyValue('background-color')
-        const border = style.getPropertyValue('border')
-        const div = document.createElement('div')
-        selector.style.border = '2px solid #000'
-        setTimeout(() => {
-          const rect =
-            event.detail.selector === 'body'
-              ? { top: 50, left: 0 }
-              : selector.getBoundingClientRect()
-          div.style.cssText = `position:absolute;z-index:5000;top:${rect.top -
-            50}px;left:${rect.left}px;background-color:#fff;`
-          div.innerHTML = `${duration}ms<br>${event.detail.stimulusReflex.reflexId}`
-          document.body.appendChild(div)
-          wireframes.fromTo(
-            selector,
-            {
-              backgroundColor:
-                event.type === 'cable-ready:after-morph' ? '#FF9800' : '#0F0'
-            },
-            {
-              backgroundColor,
-              duration: 5,
-              ease: 'power4',
-              onComplete: () => {
-                wireframes.fromTo(
-                  div,
-                  { opacity: 1 },
-                  {
-                    opacity: 0,
-                    onComplete: () => {
-                      selector.style.border = border
-                      div.remove()
-                    }
-                  }
-                )
-              }
-            }
-          )
-        })
-      }
-      if (!promises[event.detail.stimulusReflex.reflexId])
-        delete Log.logs[event.detail.stimulusReflex.reflexId]
-    }
+    const { stimulusReflex } = event.detail || {}
+    if (!stimulusReflex) return
+    if (!promises[event.detail.stimulusReflex.reflexId])
+      delete Log.logs[event.detail.stimulusReflex.reflexId]
   }
 
   document.addEventListener(

--- a/lib/stimulus_reflex/broadcasters/broadcaster.rb
+++ b/lib/stimulus_reflex/broadcasters/broadcaster.rb
@@ -31,7 +31,7 @@ module StimulusReflex
         detail: {
           reflexId: data["reflexId"],
           stimulus_reflex: data.merge(
-            broadcaster: to_sym,
+            morph: to_sym,
             server_message: {subject: subject, body: body}
           )
         }

--- a/lib/stimulus_reflex/broadcasters/broadcaster.rb
+++ b/lib/stimulus_reflex/broadcasters/broadcaster.rb
@@ -24,7 +24,7 @@ module StimulusReflex
       false
     end
 
-    def enqueue_message(subject:, body: nil, data: {})
+    def broadcast_message(subject:, body: nil, data: {}, error: nil)
       logger.error "\e[31m#{body}\e[0m" if subject == "error"
       cable_ready[stream_name].dispatch_event(
         name: "stimulus-reflex:server-message",
@@ -32,14 +32,10 @@ module StimulusReflex
           reflexId: data["reflexId"],
           stimulus_reflex: data.merge(
             morph: to_sym,
-            server_message: {subject: subject, body: body}
+            server_message: {subject: subject, body: error&.to_s}
           )
         }
       )
-    end
-
-    def broadcast_message(subject:, body: nil, data: {})
-      enqueue_message subject: subject, body: body, data: data
       cable_ready.broadcast
     end
 

--- a/lib/stimulus_reflex/broadcasters/page_broadcaster.rb
+++ b/lib/stimulus_reflex/broadcasters/page_broadcaster.rb
@@ -18,7 +18,7 @@ module StimulusReflex
           children_only: true,
           permanent_attribute_name: permanent_attribute_name,
           stimulus_reflex: data.merge({
-            broadcaster: to_sym
+            morph: to_sym
           })
         )
       end

--- a/lib/stimulus_reflex/broadcasters/selector_broadcaster.rb
+++ b/lib/stimulus_reflex/broadcasters/selector_broadcaster.rb
@@ -17,7 +17,7 @@ module StimulusReflex
               children_only: true,
               permanent_attribute_name: permanent_attribute_name,
               stimulus_reflex: data.merge({
-                broadcaster: to_sym
+                morph: to_sym
               })
             )
           else
@@ -25,7 +25,7 @@ module StimulusReflex
               selector: selector,
               html: fragment.to_html,
               stimulus_reflex: data.merge({
-                broadcaster: to_sym
+                morph: to_sym
               })
             )
           end

--- a/lib/stimulus_reflex/channel.rb
+++ b/lib/stimulus_reflex/channel.rb
@@ -44,10 +44,10 @@ class StimulusReflex::Channel < ApplicationCable::Channel
         delegate_call_to_reflex reflex, method_name, arguments
       rescue => invoke_error
         message = exception_message_with_backtrace(invoke_error)
-        body = "StimulusReflex::Channel Failed to invoke #{target}! #{url} #{message}"
+        body = "Reflex #{target} failed: #{message} [#{url}]"
         if reflex
           reflex.rescue_with_handler(invoke_error)
-          reflex.broadcast_message subject: "error", body: body, data: data
+          reflex.broadcast_message subject: "error", body: body, data: data, error: invoke_error
         else
           logger.error "\e[31m#{body}\e[0m"
         end
@@ -62,7 +62,8 @@ class StimulusReflex::Channel < ApplicationCable::Channel
         rescue => render_error
           reflex.rescue_with_handler(render_error)
           message = exception_message_with_backtrace(render_error)
-          reflex.broadcast_message subject: "error", body: "StimulusReflex::Channel Failed to re-render #{url} #{message}", data: data
+          body = "Reflex failed to re-render: #{message} [#{url}]"
+          reflex.broadcast_message subject: "error", body: body, data: data, error: render_error
         end
       end
     ensure
@@ -105,6 +106,6 @@ class StimulusReflex::Channel < ApplicationCable::Channel
   end
 
   def exception_message_with_backtrace(exception)
-    "#{exception} #{exception.backtrace.first}"
+    "#{exception}\n#{exception.backtrace.first}"
   end
 end


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Refactoring

## Description

What originally started as an exploration of wireframe feedback mechanisms became an overhaul of both when we process post-Reflex lifecycle moments as well as an opportunity to revisit the logging mechanism itself.

Upon investigation, I realized that the library was processing lifecycle mechanisms in response to the `before` events emitted by CableReady. It would also only report the information for one morph operation, even if there are several. Worse, the durations reported were not accurate as they do not include time spent modifying the DOM. Large, complex DOMs can take several ms to update. Finally, while v3.3.0 improved the callbacks handling significantly, so long as we're executing `after` callbacks before the operations have actually been called means that there's a very real possibility `after` callbacks will be based on outdated state.

Now, the tradeoff in moving to using CableReady `after` events is that there's a chance someone could remove the selector that is supposed to hold their Stimulus controller, meaning that `afterReflex` callbacks could not fire. I would argue that not only is this a brittle configuration, based on a perception of the library before multiple selector morphs was possible, but that there could easily be a race condition where a DOM element gets removed before or after the current callback is processing. I feel strongly that we should simply explain the situation via documentation: if you remove an element that holds a controller, that controller cannot emit Reflex callbacks.

In terms of the logging itself, I put a lot of energy into thinking about what information is most useful when, and in what format and configuration. We had a lot of long keys, superfluous data and repetition between the message sending to the server and any replies coming back.

Here is the debug output for the following:
```ruby
    morph "#results", html
    morph "#test1", "<div id='test1'><span>I am content<span></div>"
    morph "#test2", "<div>My content rocks</div>"
```
<img width="685" alt="selector morphs" src="https://user-images.githubusercontent.com/38150464/94399708-e44bcf00-0135-11eb-9651-68168821b7ad.png">

Note that the logs are numbered in the order that they finish. This reflects the fact that a `morph` takes longer to execute. Also, `#test2` is not a valid payload for `morph` so it is processed with `inner_html`.

```ruby
  morph :nothing
```
<img width="715" alt="nothing morph" src="https://user-images.githubusercontent.com/38150464/94400069-82d83000-0136-11eb-86bd-ad9eac09f320.png">

Nothing morph updates ♾️ 

```ruby
  before_reflex do
    throw :abort
  end
```
<img width="696" alt="throw :abort" src="https://user-images.githubusercontent.com/38150464/94400256-c894f880-0136-11eb-8880-74cbfeccb6aa.png">

So does a halted Reflex.

## Why should this be added

This could assist with troubleshooting and debugging, as well as provide insight into what method is being used to update your DOM

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
