### PR TITLE
Force request encodings to be UTF-8 instead of ASCII-8BIT after a reflex

### DIFF
--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -43,7 +43,7 @@ class StimulusReflex::Reflex
     end
   end
 
-  attr_reader :channel, :url, :url_params, :element, :selectors, :method_name, :broadcaster, :permanent_attribute_name
+  attr_reader :channel, :url, :element, :selectors, :method_name, :broadcaster, :permanent_attribute_name
 
   delegate :connection, :stream_name, to: :channel
   delegate :session, to: :request
@@ -82,11 +82,11 @@ class StimulusReflex::Reflex
       env = connection.env.merge(mock_env)
       req = ActionDispatch::Request.new(env)
 
-      @url_params = Rails.application.routes.recognize_path_with_request(req, url, req.env[:extras] || {})
-      @url_params[:controller] = @url_params[:controller].force_encoding("UTF-8")
-      @url_params[:action] = @url_params[:action].force_encoding("UTF-8")
+      path_params = Rails.application.routes.recognize_path_with_request(req, url, req.env[:extras] || {})
+      path_params[:controller] = path_params[:controller].force_encoding("UTF-8")
+      path_params[:action] = path_params[:action].force_encoding("UTF-8")
 
-      req.env.merge(ActionDispatch::Http::Parameters::PARAMETERS_KEY => @url_params)
+      req.env.merge(ActionDispatch::Http::Parameters::PARAMETERS_KEY => path_params)
       req.env["action_dispatch.request.parameters"] = req.parameters.merge(@params)
       req.tap { |r| r.session.send :load! }
     end


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bug Fix

## Description

This was a really hard one! Spent the last few hours debugging where that ASCII-8BIT came from. 

Calling `Rack::MockRequest.env_for()` in `lib/stimulus_reflex/reflex.rb` returns for some reason a Hash with some ASCII-8BIT strings. Specifically those are the strings which are encoded as ASCII-8BIT:

```ruby
mock_env

=> { 
  [...] 
  "REQUEST_METHOD"=>"GET", 
  "SERVER_NAME"=>"localhost", 
  "SERVER_PORT"=>"3000", 
  "QUERY_STRING"=>"", 
  "PATH_INFO"=>"/", 
  "HTTPS"=>"off", 
  [...]
}
```

This happens because `Rack::MockRequest.env_for()` encodes it's input as `Encoding::BINARY` which results in ASCII-8BIT. See below for reference in rack/rack:

https://github.com/rack/rack/blob/4db9d299e43dbf856664359b16e2e461c378ee1c/lib/rack/mock.rb#L155-L158

With this hash we are building a new `ActionDispatch::Request` which we then pass into `Rails.application.routes.recognize_path_with_request()`.

This then returns the following Hash which also contains ASCII-8BIT strings as a result: 

```ruby
@url_params

=> {
  "action": "index",
  "controller": "todos"
}
``` 

Not quite sure if this also impacts this issue, but they are again converted to ASCII-8BIT in `RouteSet#recognize_path_with_request`. See `rails/rails` for reference:

https://github.com/rails/rails/blob/60ef07093d9023568ccbbd34e862b40395ec02f4/actionpack/lib/action_dispatch/routing/route_set.rb#L866-L868.

The strings in this `@url_params` hash get passed around the whole Rails stack and finally end up as `controller.action_name` and `action_name` in the views. This is why @asgerb encountered the `Can not transliterate strings with ASCII-8BIT encoding` error when calling `action_name.parameterize`.

This commit converts the values of `:action` and `:controller` in `@url_params` back to UTF-8 strings as they should be (this is the case if you render the view normally).

I didn't find another way in the `Rack::MockRequest.env_for()` or `Rails.application.routes.recognize_path_with_request()` call to enforce those strings to be UTF-8 even earlier.

This PR also untangles the `StimulusReflex::Reflex#request` method a little bit, which should make it easier to follow and easier to understand. There is a whole lot going on the  env merging.

Finally Resolves #202. 

/cc @asgerb could you check if this resolves your issue? Thank you!

## Why should this be added

Fixes the edge case in #202 where the `action_name` was converted to a ASCII-8BIT string. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
