### PR TITLE
Move StimulusReflex::Channel to app/ and allow for a configurable parent channel

### DIFF
--- a/app/channels/stimulus_reflex/channel.rb
+++ b/app/channels/stimulus_reflex/channel.rb
@@ -1,16 +1,6 @@
 # frozen_string_literal: true
 
-module ApplicationCable
-  class Channel < ActionCable::Channel::Base
-    def initialize(connection, identifier, params = {})
-      super
-      application_channel = Rails.root.join("app", "channels", "application_cable", "channel.rb")
-      require application_channel if File.exist?(application_channel)
-    end
-  end
-end
-
-class StimulusReflex::Channel < ApplicationCable::Channel
+class StimulusReflex::Channel < StimulusReflex.parent_channel.constantize
   def stream_name
     ids = connection.identifiers.map { |identifier| send(identifier).try(:id) || send(identifier) }
     [

--- a/lib/stimulus_reflex.rb
+++ b/lib/stimulus_reflex.rb
@@ -11,7 +11,6 @@ require "cable_ready"
 require "stimulus_reflex/version"
 require "stimulus_reflex/reflex"
 require "stimulus_reflex/element"
-require "stimulus_reflex/channel"
 require "stimulus_reflex/sanity_checker"
 require "stimulus_reflex/broadcasters/broadcaster"
 require "stimulus_reflex/broadcasters/nothing_broadcaster"
@@ -20,6 +19,14 @@ require "stimulus_reflex/broadcasters/selector_broadcaster"
 require "generators/stimulus_reflex_generator"
 
 module StimulusReflex
+  # Parent channel class for StimulusReflex channels.
+  mattr_accessor :parent_channel
+  @@parent_channel = "ApplicationCable::Channel"
+
+  def self.setup
+    yield self
+  end
+
   class Engine < Rails::Engine
     initializer "stimulus_reflex.sanity_check" do
       SanityChecker.check!


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Feature/enhancement and bug fix

## Description

### Feature/Enhancement

Allows the parent class of `StimulusReflex::Channel` to be configurable via `StimulusReflex.parent_channel`. This can be done in an initializer...

```ruby
StimulusReflex.setup do |config|
  config.parent_channel = 'SomeChannelThatsNotStandard'
end
```

It defaults to `ApplicationCable::Channel` as it currently does.

### Bug Fix

This came about while attempting an upgrade because for some reason my app's own `ApplicationCable::Channel` implementation was not being loaded correctly, but only in certain situations. For instance, passenger in would not load the file, but puma would. There are mysterious forces at work in the Rails loading mechanisms and all of the various pieces that touch it, and they sometimes have different behaviour.

In putting together this PR, a second issue was discovered that is not specific to my app. Because SR is overriding `ApplicationCable::Channel#initialize` and then doing a `require` on the user-supplied implementation, the user-supplied implementation gets skipped on the first call to a channel's `#initialize` method. Thus, if the user supplies their own `ApplicationCable::Channel#initialize` method, it will only start to be used after at least one ActionCable connection is made, as that will cause the SR implementation to be called first, which itself then overwrites its own implementation via the `require`. Because this PR avoids overriding `ApplicationCable::Channel` in any way, we avoid this oddity. As to why anyone would override `ApplicationCable::Channel#initialize` is another matter, but regardless, this PR avoids this behaviour.

## Why should this be added

* It is possible that someone would want to provide a different parent class to `StimulusReflex::Channel`, or otherwise name their base channel something else entirely. This allows them to configure this behaviour, with the default being as it was before.

* It avoids a small issue discovered when calling a user-supplied `ApplicationCable::Channel#initialize`.

* Reduces code complexity by avoiding having to override `ApplicationCable::Channel` in SR.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
