### PR TITLE
Fix form autosave docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -469,6 +469,10 @@
 
 [Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v2.1.9...v2.2.0)
 
+**Implemented enhancements:**
+
+- Explicit and implicit registering of the ActionCable consumer [\#116](https://github.com/hopsoft/stimulus_reflex/pull/116) ([hopsoft](https://github.com/hopsoft))
+
 ## [v2.1.9](https://github.com/hopsoft/stimulus_reflex/tree/v2.1.9) (2020-02-20)
 
 [Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v2.1.8...v2.1.9)
@@ -522,7 +526,6 @@
 **Implemented enhancements:**
 
 - Custom Stimulus schema breaks Reflex [\#91](https://github.com/hopsoft/stimulus_reflex/issues/91)
-- Explicit and implicit registering of the ActionCable consumer [\#116](https://github.com/hopsoft/stimulus_reflex/pull/116) ([hopsoft](https://github.com/hopsoft))
 - Add schema support [\#94](https://github.com/hopsoft/stimulus_reflex/pull/94) ([hopsoft](https://github.com/hopsoft))
 - inherit stimulus schema [\#92](https://github.com/hopsoft/stimulus_reflex/pull/92) ([nickyvanurk](https://github.com/nickyvanurk))
 - Single source of truth [\#76](https://github.com/hopsoft/stimulus_reflex/pull/76) ([leastbad](https://github.com/leastbad))

--- a/docs/working-with-forms.md
+++ b/docs/working-with-forms.md
@@ -158,13 +158,13 @@ Now, let's create the markup for our form, which will submit to the `Post` Refle
 
   <div>
     <%= form.label :name %>
-    <%= form.text_field :name, data: { reflex: "change->PostReflex#submit" } %>
+    <%= form.text_field :name, data: { reflex: "change->PostReflex#submit", reflex_dataset: "combined" } %>
   </div>
 
   <%= form.fields_for :comments, @post.comments do |comment_form| %>
     <%= comment_form.hidden :id %>
     <%= comment_form.label :name %>
-    <%= comment_form.text_field :name, data: { reflex: "change->PostReflex#submit" } %>
+    <%= comment_form.text_field :name, data: { reflex: "change->PostReflex#submit", reflex_dataset: "combined" } %>
   <% end %>
 
   <%= link_to "New comment", "#", data: { reflex: "click->PostReflex#build_comment" } %>


### PR DESCRIPTION
# Documentation

## Description

Found out that the autosave form example will only work with `data-reflex-dataset="combined"`, thanks @RolandStuder 

## Checklist

- [X] My code follows the style guidelines of this project
- [X] Checks (StandardRB & Prettier-Standard) are passing
