### PR TITLE
introduce tab isolation mode

### DIFF
--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -35,7 +35,10 @@ let actionCableSubscriptionActive = false
 window.reflexes = {}
 
 // Indicates if we should log calls to stimulate, etc...
-let debugging = false
+let debugging
+
+// Should Reflex playback be restricted to the tab that called it?
+let isolationMode
 
 // Subscribes a StimulusReflex controller to an ActionCable channel.
 // controller - the StimulusReflex controller to subscribe
@@ -73,7 +76,8 @@ const createSubscription = controller => {
           reflexes[reflexId].pendingOperations = 0
           reflexes[reflexId].completedOperations = 0
         }
-        CableReady.perform(data.operations)
+        if (reflexes[reflexId] || !isolationMode)
+          CableReady.perform(data.operations)
       },
       connected: () => {
         actionCableSubscriptionActive = true
@@ -376,11 +380,15 @@ const getReflexRoots = element => {
 // - options
 //   * controller - [optional] the default StimulusReflexController
 //   * consumer - [optional] the ActionCable consumer
+//   * debug - [false] log all Reflexes to the console
+//   * params - [{}] key/value parameters to send during channel subscription
+//   * isolate - [false] restrict Reflex playback to the tab which initiated it
 //
 const initialize = (application, initializeOptions = {}) => {
-  const { controller, consumer, debug, params } = initializeOptions
+  const { controller, consumer, debug, params, isolate } = initializeOptions
   actionCableConsumer = consumer
   actionCableParams = params
+  isolationMode = !!isolate
   stimulusApplication = application
   stimulusApplication.schema = { ...defaultSchema, ...application.schema }
   stimulusApplication.register(

--- a/lib/tasks/stimulus_reflex/install.rake
+++ b/lib/tasks/stimulus_reflex/install.rake
@@ -42,7 +42,8 @@ namespace :stimulus_reflex do
     end
 
     initialize_line = lines.find { |line| line.start_with?("StimulusReflex.initialize") }
-    lines << "StimulusReflex.initialize(application, { consumer, controller, debug: false })\n" unless initialize_line
+    lines << "StimulusReflex.initialize(application, { consumer, controller, isolate: true })\n" unless initialize_line
+    lines << "if (process.env.RAILS_ENV === 'development') StimulusReflex.debug = true\n" unless initialize_line
     File.open(filepath, "w") { |f| f.write lines.join }
 
     filepath = Rails.root.join("config/environments/development.rb")


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Enhancement

## Description

Pass `isolate: true` to the SR initialization to put the library in tab isolation mode. SR-initiated CableReady events will only fire in the tab that created them.

`StimulusReflex.initialize(application, { isolate: true })`

## Why should this be added

Some developers have users with multiple tabs open at once. This will ensure that those developers have a mechanism to restrict Reflex execution to only the tab which initiated them.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
