### PR TITLE
Opt-in form serialization & params overriding

### DIFF
--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -114,7 +114,7 @@ const extendStimulusController = controller => {
     //
     // - target - the reflex target (full name of the server side reflex) i.e. 'ReflexClassName#method'
     // - element - [optional] the element that triggered the reflex, defaults to this.element
-    // - options - [optional] an object that contains at least one of attrs, reflexId, selectors
+    // - options - [optional] an object that contains at least one of attrs, reflexId, selectors, resolveLate, skipFormSerialization
     // - *args - remaining arguments are forwarded to the server side reflex method
     //
     stimulate () {
@@ -137,7 +137,7 @@ const extendStimulusController = controller => {
         args[0] &&
         typeof args[0] == 'object' &&
         Object.keys(args[0]).filter(key =>
-          ['attrs', 'selectors', 'reflexId', 'resolveLate'].includes(key)
+          ['attrs', 'selectors', 'reflexId', 'resolveLate', 'skipFormSerialization'].includes(key)
         ).length
       ) {
         const opts = args.shift()
@@ -178,14 +178,15 @@ const extendStimulusController = controller => {
 
       setTimeout(() => {
         const { params } = element.reflexData || {}
+        const skipFormSerialization = options['skipFormSerialization'] || false
         element.reflexData = {
           ...data,
           params: {
-            ...params,
-            ...serializeForm(element.closest('form'), {
+            ...!skipFormSerialization && serializeForm(element.closest('form'), {
               hash: true,
               empty: true
-            })
+            }),
+            ...params
           }
         }
 

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -184,12 +184,13 @@ const extendStimulusController = controller => {
 
       setTimeout(() => {
         const { params } = element.reflexData || {}
-        const formData = options['serialize'] == false
-          ? {}
-          : serializeForm(element.closest('form'), {
-              hash: true,
-              empty: true
-            })
+        const formData =
+          options['serialize'] == false
+            ? {}
+            : serializeForm(element.closest('form'), {
+                hash: true,
+                empty: true
+              })
         element.reflexData = {
           ...data,
           params: {

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -137,7 +137,13 @@ const extendStimulusController = controller => {
         args[0] &&
         typeof args[0] == 'object' &&
         Object.keys(args[0]).filter(key =>
-          ['attrs', 'selectors', 'reflexId', 'resolveLate', 'skipFormSerialization'].includes(key)
+          [
+            'attrs',
+            'selectors',
+            'reflexId',
+            'resolveLate',
+            'skipFormSerialization'
+          ].includes(key)
         ).length
       ) {
         const opts = args.shift()
@@ -179,13 +185,16 @@ const extendStimulusController = controller => {
       setTimeout(() => {
         const { params } = element.reflexData || {}
         const skipFormSerialization = options['skipFormSerialization'] || false
+        const formData = skipFormSerialization
+          ? {}
+          : serializeForm(element.closest('form'), {
+              hash: true,
+              empty: true
+            })
         element.reflexData = {
           ...data,
           params: {
-            ...!skipFormSerialization && serializeForm(element.closest('form'), {
-              hash: true,
-              empty: true
-            }),
+            ...formData,
             ...params
           }
         }

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -114,7 +114,7 @@ const extendStimulusController = controller => {
     //
     // - target - the reflex target (full name of the server side reflex) i.e. 'ReflexClassName#method'
     // - element - [optional] the element that triggered the reflex, defaults to this.element
-    // - options - [optional] an object that contains at least one of attrs, reflexId, selectors, resolveLate, skipFormSerialization
+    // - options - [optional] an object that contains at least one of attrs, reflexId, selectors, resolveLate, serialize
     // - *args - remaining arguments are forwarded to the server side reflex method
     //
     stimulate () {
@@ -142,7 +142,7 @@ const extendStimulusController = controller => {
             'selectors',
             'reflexId',
             'resolveLate',
-            'skipFormSerialization'
+            'serialize'
           ].includes(key)
         ).length
       ) {
@@ -184,8 +184,7 @@ const extendStimulusController = controller => {
 
       setTimeout(() => {
         const { params } = element.reflexData || {}
-        const skipFormSerialization = options['skipFormSerialization'] || false
-        const formData = skipFormSerialization
+        const formData = options['serialize'] == false
           ? {}
           : serializeForm(element.closest('form'), {
               hash: true,

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -114,7 +114,7 @@ const extendStimulusController = controller => {
     //
     // - target - the reflex target (full name of the server side reflex) i.e. 'ReflexClassName#method'
     // - element - [optional] the element that triggered the reflex, defaults to this.element
-    // - options - [optional] an object that contains at least one of attrs, reflexId, selectors, resolveLate, serialize
+    // - options - [optional] an object that contains at least one of attrs, reflexId, selectors, resolveLate, serializeForm
     // - *args - remaining arguments are forwarded to the server side reflex method
     //
     stimulate () {
@@ -142,7 +142,7 @@ const extendStimulusController = controller => {
             'selectors',
             'reflexId',
             'resolveLate',
-            'serialize'
+            'serializeForm'
           ].includes(key)
         ).length
       ) {
@@ -185,7 +185,7 @@ const extendStimulusController = controller => {
       setTimeout(() => {
         const { params } = element.reflexData || {}
         const formData =
-          options['serialize'] == false
+          options['serializeForm'] == false
             ? {}
             : serializeForm(element.closest('form'), {
                 hash: true,


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Feature

## Description

First of all I would like to thank you for your great project, like a breath of fresh air! 

This PR introduces new option `skipFormSerialization: true|false` for `stimulate` method to disable form serialization into `params`. Also it changes the order final `params` are produced, by applying  `params` set in client `before` lifecycle callback over serialized form. 

Might be a sort of workaround for #321 by providing a way for custom form serialization.

## Why should this be added
As a developer I want to have a control over what is passed to server and have least surprises there. #208 had changed the way `params` are produced by giving priority for general case (form serialization) over specific case (passing custom params or their overwriting in client’s `before` callback). This steals control from developer. This PR tries to provide this control back.

Also some of my use-cases don’t require form serialization at all. I.e. I’m just call `stimulate` in my Stimulus controller with all args/parameters I need and produce some sprinkles server-side using `nothing` morphs and CableReady methods. IMO having an option to opt out of (quite large in my case) form serialization would be great in such cases.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
