### PR TITLE
fix for PR#317 which was preventing server messages

### DIFF
--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -56,6 +56,8 @@ const createSubscription = controller => {
     actionCableConsumer.subscriptions.create(subscription, {
       received: data => {
         if (!data.cableReady) return
+        if (data.operations['dispatchEvent'])
+          return CableReady.perform(data.operations)
         totalOperations = 0
         ;['morph', 'innerHtml'].forEach(operation => {
           if (data.operations[operation] && data.operations[operation].length) {
@@ -472,10 +474,11 @@ if (!document.stimulusReflexInitialized) {
     })
 
     reflexes[reflexId].finalStage = subject == 'halted' ? 'halted' : 'after'
-    if (element && subjects[subject])
-      dispatchLifecycleEvent(subject, element, reflexId)
 
     if (debugging) Log[subject == 'error' ? 'error' : 'success'](event)
+
+    if (element && subjects[subject])
+      dispatchLifecycleEvent(subject, element, reflexId)
   })
 }
 


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bug fix

## Description

Refactoring in #317 introduced a bug which prevented CableReady operations from firing in the case of a server message. This PR fixes that issue by handling `dispatchEvent` operations as a separate case.

## Why should this be added

Error messages were being squelched.

This also should address the missing `promise.timestamp` issue that @joshleblanc saw. That condition happens if `Log.error` is called after the `finalize` stage, because the promise no longer exists.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
