### PR TITLE
merge environment into ApplicationController and descendants

### DIFF
--- a/lib/stimulus_reflex/channel.rb
+++ b/lib/stimulus_reflex/channel.rb
@@ -21,6 +21,7 @@ class StimulusReflex::Channel < ApplicationCable::Channel
 
   def subscribed
     super
+    fix_environment!
     stream_from stream_name
   end
 
@@ -107,5 +108,11 @@ class StimulusReflex::Channel < ApplicationCable::Channel
 
   def exception_message_with_backtrace(exception)
     "#{exception}\n#{exception.backtrace.first}"
+  end
+
+  def fix_environment!
+    ([ApplicationController] + ApplicationController.descendants).each do |controller|
+      controller.renderer.instance_variable_set(:@env, connection.env.merge(controller.renderer.instance_variable_get(:@env)))
+    end
   end
 end


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bug fix

## Description

Many support requests come in because people have issues with `ApplicationController.render` (and descendants) not seeing the environment variables available outside of an ActionCable connection. This resolves the issue for all controllers.

Note that @julianrubisch did all of the hard work to find a workaround while working on Futurism. I am just schlepping the solution into SR so we can all benefit from his eureka moment.

## Why should this be added

This corrects what appears to be a Rails bug and permits people to call helpers which use environment variables eg. `current_user`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
