### PR TITLE
add signed/unsigned accessors to element

### DIFF
--- a/lib/stimulus_reflex/element.rb
+++ b/lib/stimulus_reflex/element.rb
@@ -10,6 +10,14 @@ class StimulusReflex::Element < OpenStruct
     super all_attributes.merge(all_attributes.transform_keys(&:underscore))
     @data_attributes.transform_keys! { |key| key.delete_prefix "data-" }
   end
+  
+  def signed
+    @signed ||= ->(accessor) { GlobalID::Locator.locate_signed(dataset[accessor]) }
+  end
+  
+  def unsigned
+    @unsigned ||= ->(accessor) { GlobalID::Locator.locate(dataset[accessor]) }
+  end
 
   def dataset
     @dataset ||= OpenStruct.new(data_attributes.merge(data_attributes.transform_keys(&:underscore)))

--- a/lib/stimulus_reflex/element.rb
+++ b/lib/stimulus_reflex/element.rb
@@ -10,11 +10,11 @@ class StimulusReflex::Element < OpenStruct
     super all_attributes.merge(all_attributes.transform_keys(&:underscore))
     @data_attributes.transform_keys! { |key| key.delete_prefix "data-" }
   end
-  
+
   def signed
     @signed ||= ->(accessor) { GlobalID::Locator.locate_signed(dataset[accessor]) }
   end
-  
+
   def unsigned
     @unsigned ||= ->(accessor) { GlobalID::Locator.locate(dataset[accessor]) }
   end


### PR DESCRIPTION
# Feature

## Description

This is an expiremental idea that we're hashing out in discord. Provide accessors on `element` that allow implicitly locating signed and unsigned global IDs.

With this change, you can use `element.signed[:foo]` or `element.unsigned[:foo]` to map the dataset attribute `foo` to a model.

```ruby
class MyReflex < ApplicationReflex
  def add_comment
    comment = element.signed[:comment]
    comment.update(content: params[:content] if comment
  end
end
```

## Why should this be added

Developer happiness 

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] Checks (StandardRB & Prettier-Standard) are passing
