### PR TITLE
remove isolate concept and make behavior default

### DIFF
--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -37,9 +37,6 @@ window.reflexes = {}
 // Indicates if we should log calls to stimulate, etc...
 let debugging
 
-// Should Reflex playback be restricted to the tab that called it?
-let isolationMode
-
 // Subscribes a StimulusReflex controller to an ActionCable channel.
 // controller - the StimulusReflex controller to subscribe
 //
@@ -78,8 +75,7 @@ const createSubscription = controller => {
           reflexes[reflexId].pendingOperations = 0
           reflexes[reflexId].completedOperations = 0
         }
-        if (reflexes[reflexId] || !isolationMode)
-          CableReady.perform(data.operations)
+        if (reflexes[reflexId]) CableReady.perform(data.operations)
       },
       connected: () => {
         actionCableSubscriptionActive = true
@@ -387,10 +383,9 @@ const getReflexRoots = element => {
 //   * isolate - [false] restrict Reflex playback to the tab which initiated it
 //
 const initialize = (application, initializeOptions = {}) => {
-  const { controller, consumer, debug, params, isolate } = initializeOptions
+  const { controller, consumer, debug, params } = initializeOptions
   actionCableConsumer = consumer
   actionCableParams = params
-  isolationMode = !!isolate
   stimulusApplication = application
   stimulusApplication.schema = { ...defaultSchema, ...application.schema }
   stimulusApplication.register(

--- a/lib/tasks/stimulus_reflex/install.rake
+++ b/lib/tasks/stimulus_reflex/install.rake
@@ -42,7 +42,7 @@ namespace :stimulus_reflex do
     end
 
     initialize_line = lines.find { |line| line.start_with?("StimulusReflex.initialize") }
-    lines << "StimulusReflex.initialize(application, { consumer, controller, isolate: true })\n" unless initialize_line
+    lines << "StimulusReflex.initialize(application, { consumer, controller })\n" unless initialize_line
     lines << "if (process.env.RAILS_ENV === 'development') StimulusReflex.debug = true\n" unless initialize_line
     File.open(filepath, "w") { |f| f.write lines.join }
 


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bug fix

## Description

Tab isolation is now a default assumption in v3.4+

## Why should this be added

Promise only exists in the tab in which it was created. It also just makes logical sense.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
