### PR TITLE
Delegate flash to the request

### DIFF
--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -46,7 +46,7 @@ class StimulusReflex::Reflex
   attr_reader :channel, :url, :element, :selectors, :method_name, :broadcaster, :permanent_attribute_name
 
   delegate :connection, :stream_name, to: :channel
-  delegate :session, to: :request
+  delegate :flash, :session, to: :request
   delegate :broadcast, :broadcast_message, to: :broadcaster
 
   def initialize(channel, url: nil, element: nil, selectors: [], method_name: nil, permanent_attribute_name: nil, params: {})


### PR DESCRIPTION
# Enhancement

## Description

Expose the Rails flash directly to the reflex by delegating to the request.

## Why should this be added

Makes using the flash more intuitive and cleans up a little verbosity in reflexes.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing