### PR TITLE
Aliases method_name to action_name

### DIFF
--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -45,6 +45,8 @@ class StimulusReflex::Reflex
 
   attr_reader :channel, :url, :element, :selectors, :method_name, :broadcaster, :permanent_attribute_name
 
+  alias action_name method_name # for compatibility with controller libraries like Pundit that expect an action name
+
   delegate :connection, :stream_name, to: :channel
   delegate :flash, :session, to: :request
   delegate :broadcast, :broadcast_message, to: :broadcaster


### PR DESCRIPTION
Aliases method_name to action_name for better compatibility with controller libraries like Pundit

# Type of PR (feature, enhancement, bug fix, etc.)

Enhancement

## Description

One-line change, aliases method_name to action_name

Fixes # (issue)

## Why should this be added

Provides compatibility with Pundit and potentially other libraries that enhance the controller layer.

## Checklist

- [x ] My code follows the style guidelines of this project
- [x ] Checks (StandardRB & Prettier-Standard) are passing
