### PR TITLE
Get package version from second line in the yarn.lock

### DIFF
--- a/lib/stimulus_reflex/sanity_checker.rb
+++ b/lib/stimulus_reflex/sanity_checker.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class StimulusReflex::SanityChecker
-  NODE_VERSION_FORMAT = /(\d+\.\d+\.\d+.*):/
-  JSON_VERSION_FORMAT = /(\d+\.\d+\.\d+.*)"/
-
   def self.check!
     instance = new
     instance.check_caching_enabled
@@ -58,16 +55,13 @@ class StimulusReflex::SanityChecker
   end
 
   def find_javascript_package_version
-    if (match = search_file(yarn_lock_path, regex: /^stimulus_reflex/))
-      match[NODE_VERSION_FORMAT, 1]
-    elsif (match = search_file(yarn_link_path, regex: /version/))
-      match[JSON_VERSION_FORMAT, 1]
-    end
+    search_file(yarn_lock_path, regex: /stimulus_reflex.*\s.*version "(.*)"/) ||
+      search_file(yarn_link_path, regex: /"version": "(.*)"/)
   end
 
   def search_file(path, regex:)
     return unless File.exist?(path)
-    File.foreach(path).grep(regex).first
+    File.read(path).scan(regex).first&.first
   end
 
   def yarn_lock_path


### PR DESCRIPTION

# Bugfix

## Description

People sometimes get their NPM package directly from Github, by putting something like the following in their `package.json`:
```
    "stimulus_reflex": "leastbad/stimulus_reflex#isolation_optional"
```

In this case the sanity checker does not manage read the version (as is looked at only the first line of the `yarn.lock` entry like `stimulus_reflex@3.3.0`

So in this case people mistakenly get a version misleading info of not being able to locate the stimulus_reflex package.

## What changes

This PR makes it so the version get read from the second line of a `yarn.lock` entry (see an example entry here:)
```
stimulus_reflex@leastbad/stimulus_reflex#isolation_optional:
  version "3.3.0"
  resolved "https://codeload.github.com/leastbad/stimulus_reflex/tar.gz/543fb0f1c543e7679ddb9720cc6ddfeefd40f898"
  dependencies:
    form-serialize ">= 0.7.2"
```

Fixes the red herring we had here: https://discord.com/channels/629472241427415060/733725826411135107/770995207918845954

## Why should this be added

Value is small, but will make it easier to have have confusing information on startup in such cases.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update
