### PR TITLE
Use Webpacker folder if available

### DIFF
--- a/lib/tasks/stimulus_reflex/install.rake
+++ b/lib/tasks/stimulus_reflex/install.rake
@@ -9,7 +9,7 @@ namespace :stimulus_reflex do
     system "bundle exec rails webpacker:install:stimulus"
     gem_version = StimulusReflex::VERSION.gsub(".pre", "-pre")
     system "yarn add cable_ready stimulus_reflex@#{gem_version}"
-    main_folder = defined?(Webpacker) ? Webpacker.config.source_path.to_s.gsub(Rails.root.to_s, "") : "app/javascript"
+    main_folder = defined?(Webpacker) ? Webpacker.config.source_path.to_s.gsub("#{Rails.root}/", "") : "app/javascript"
 
     FileUtils.mkdir_p Rails.root.join("#{main_folder}/controllers"), verbose: true
     FileUtils.mkdir_p Rails.root.join("app/reflexes"), verbose: true

--- a/lib/tasks/stimulus_reflex/install.rake
+++ b/lib/tasks/stimulus_reflex/install.rake
@@ -9,15 +9,16 @@ namespace :stimulus_reflex do
     system "bundle exec rails webpacker:install:stimulus"
     gem_version = StimulusReflex::VERSION.gsub(".pre", "-pre")
     system "yarn add cable_ready stimulus_reflex@#{gem_version}"
+    main_folder = defined?(Webpacker) ? Webpacker.config.source_path.to_s.gsub(Rails.root.to_s, "") : "app/javascript"
 
-    FileUtils.mkdir_p Rails.root.join("app/javascript/controllers"), verbose: true
+    FileUtils.mkdir_p Rails.root.join("#{main_folder}/controllers"), verbose: true
     FileUtils.mkdir_p Rails.root.join("app/reflexes"), verbose: true
 
-    filepath = %w[
-      app/javascript/controllers/index.js
-      app/javascript/controllers/index.ts
-      app/javascript/packs/application.js
-      app/javascript/packs/application.ts
+    filepath = [
+      "#{main_folder}/controllers/index.js",
+      "#{main_folder}/controllers/index.ts",
+      "#{main_folder}/packs/application.js",
+      "#{main_folder}/packs/application.ts"
     ]
       .select { |path| File.exist?(path) }
       .map { |path| Rails.root.join(path) }


### PR DESCRIPTION
# Type of PR: Enhancement

## Description

My installation of stimulus_reflex was simply failing because non of the `filepath` were found.

I have a different folder than app/javascript in my Rails App: this is already defined in the webpacker configuration. 
[Of course, people might not have Webpacker installed...but maybe we could use it if it is available.](https://www.youtube.com/watch?v=XLGzFQg_1xc) :) 

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update
