### PR TITLE
StimulusReflex.debug= on left hand side

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -70,7 +70,7 @@ You can also set debug mode after you've initialized StimulusReflex. This is esp
 {% code title="app/javascript/controllers/index.js" %}
 ```javascript
 StimulusReflex.initialize(application, { consumer })
-if (process.env.RAILS_ENV === 'development') StimulusReflex.debug = true
+StimulusReflex.debug = process.env.RAILS_ENV === "development"
 ```
 {% endcode %}
 
@@ -130,7 +130,7 @@ const application = Application.start(document.documentElement, {
 const context = require.context('controllers', true, /_controller\.js$/)
 application.load(definitionsFromContext(context))
 StimulusReflex.initialize(application, { consumer })
-if (process.env.RAILS_ENV === 'development') StimulusReflex.debug = true
+StimulusReflex.debug = process.env.RAILS_ENV === "development"
 ```
 {% endcode %}
 


### PR DESCRIPTION
I think this change -- setting `StimulusReflex.debug` -- reads a little cleaner; and sits nicely underneath `StimulusReflex.initialize`.

```
StimulusReflex.debug = process.env.RAILS_ENV === "development"
```
