### PR TITLE
move `cable_ready` to development dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     stimulus_reflex (3.4.0.pre1)
-      cable_ready (>= 4.3.0)
       nokogiri
       rack
       rails (>= 5.2)
@@ -177,6 +176,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 2.0)
+  cable_ready (>= 4.3.0)
   pry
   pry-nav
   rake

--- a/lib/tasks/stimulus_reflex/install.rake
+++ b/lib/tasks/stimulus_reflex/install.rake
@@ -6,6 +6,7 @@ require "stimulus_reflex/version"
 namespace :stimulus_reflex do
   desc "Install StimulusReflex in this application"
   task install: :environment do
+    system "bundle add cable_ready"
     system "bundle exec rails webpacker:install:stimulus"
     gem_version = StimulusReflex::VERSION.gsub(".pre", "-pre")
     system "yarn add cable_ready stimulus_reflex@#{gem_version}"

--- a/stimulus_reflex.gemspec
+++ b/stimulus_reflex.gemspec
@@ -29,10 +29,10 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rack"
   gem.add_dependency "nokogiri"
   gem.add_dependency "rails", ">= 5.2"
-  gem.add_dependency "cable_ready", ">= 4.3.0"
   gem.add_dependency "redis"
 
   gem.add_development_dependency "bundler", "~> 2.0"
+  gem.add_development_dependency "cable_ready", ">= 4.3.0"
   gem.add_development_dependency "pry-nav"
   gem.add_development_dependency "pry"
   gem.add_development_dependency "rake"


### PR DESCRIPTION
# Type of PR

Enhancement

## Description

This PR enforces users to add `cable_ready` as an explicit dependency to their app's `Gemfile`.

## Why should this be added

This is to match the behavior introduced in #315. Moving `cable_ready` to the `peerDependencies` resulted that users now need to add `cable_ready` as a dependecy to the app's `package.json`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update
