### PR TITLE
pass reflex id to reflex

### DIFF
--- a/app/channels/stimulus_reflex/channel.rb
+++ b/app/channels/stimulus_reflex/channel.rb
@@ -32,7 +32,14 @@ class StimulusReflex::Channel < StimulusReflex.configuration.parent_channel.cons
     begin
       begin
         reflex_class = reflex_name.constantize.tap { |klass| raise ArgumentError.new("#{reflex_name} is not a StimulusReflex::Reflex") unless is_reflex?(klass) }
-        reflex = reflex_class.new(self, url: url, element: element, selectors: selectors, method_name: method_name, permanent_attribute_name: permanent_attribute_name, params: params)
+        reflex = reflex_class.new(self,
+          url: url,
+          element: element,
+          selectors: selectors,
+          method_name: method_name,
+          permanent_attribute_name: permanent_attribute_name,
+          params: params,
+          id: data["reflexId"])
         delegate_call_to_reflex reflex, method_name, arguments
       rescue => invoke_error
         message = exception_message_with_backtrace(invoke_error)

--- a/app/channels/stimulus_reflex/channel.rb
+++ b/app/channels/stimulus_reflex/channel.rb
@@ -39,7 +39,7 @@ class StimulusReflex::Channel < StimulusReflex.configuration.parent_channel.cons
           method_name: method_name,
           permanent_attribute_name: permanent_attribute_name,
           params: params,
-          id: data["reflexId"])
+          reflex_id: data["reflexId"])
         delegate_call_to_reflex reflex, method_name, arguments
       rescue => invoke_error
         message = exception_message_with_backtrace(invoke_error)

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -43,7 +43,7 @@ class StimulusReflex::Reflex
     end
   end
 
-  attr_reader :channel, :url, :element, :selectors, :method_name, :broadcaster, :permanent_attribute_name, :id
+  attr_reader :channel, :url, :element, :selectors, :method_name, :broadcaster, :permanent_attribute_name, :reflex_id
 
   alias_method :action_name, :method_name # for compatibility with controller libraries like Pundit that expect an action name
 
@@ -51,7 +51,7 @@ class StimulusReflex::Reflex
   delegate :flash, :session, to: :request
   delegate :broadcast, :broadcast_message, to: :broadcaster
 
-  def initialize(channel, url: nil, element: nil, selectors: [], method_name: nil, permanent_attribute_name: nil, params: {}, id: nil)
+  def initialize(channel, url: nil, element: nil, selectors: [], method_name: nil, permanent_attribute_name: nil, params: {}, reflex_id: nil)
     @channel = channel
     @url = url
     @element = element
@@ -60,8 +60,8 @@ class StimulusReflex::Reflex
     @params = params
     @permanent_attribute_name = permanent_attribute_name
     @broadcaster = StimulusReflex::PageBroadcaster.new(self)
-    @id = id
-    
+    @reflex_id = reflex_id
+
     self.params
   end
 

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -61,7 +61,6 @@ class StimulusReflex::Reflex
     @permanent_attribute_name = permanent_attribute_name
     @broadcaster = StimulusReflex::PageBroadcaster.new(self)
     @reflex_id = reflex_id
-
     self.params
   end
 

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -60,6 +60,8 @@ class StimulusReflex::Reflex
     @params = params
     @permanent_attribute_name = permanent_attribute_name
     @broadcaster = StimulusReflex::PageBroadcaster.new(self)
+    @id = id
+    
     self.params
   end
 

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -43,7 +43,7 @@ class StimulusReflex::Reflex
     end
   end
 
-  attr_reader :channel, :url, :element, :selectors, :method_name, :broadcaster, :permanent_attribute_name
+  attr_reader :channel, :url, :element, :selectors, :method_name, :broadcaster, :permanent_attribute_name, :id
 
   alias_method :action_name, :method_name # for compatibility with controller libraries like Pundit that expect an action name
 
@@ -51,7 +51,7 @@ class StimulusReflex::Reflex
   delegate :flash, :session, to: :request
   delegate :broadcast, :broadcast_message, to: :broadcaster
 
-  def initialize(channel, url: nil, element: nil, selectors: [], method_name: nil, permanent_attribute_name: nil, params: {})
+  def initialize(channel, url: nil, element: nil, selectors: [], method_name: nil, permanent_attribute_name: nil, params: {}, id: nil)
     @channel = channel
     @url = url
     @element = element


### PR DESCRIPTION
# Enhancement

## Description

A reflex ID is generated on the client side and is used to uniquely identify a reflex. 

It seems to reason that this property should belong to the reflex class as well, instead of floating in the ether. Specifically, I need this when extending the `Reflex` class, and manually calling `cableready.morph`, since the SR is expecting to receive it on the client side.

Just as a little explanation, right now the `data` object that the channel receives is passed around to the broadcasters, so the `reflexId` is never actually available outside of the channel. This makes it available.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update
