### PR TITLE
Add guard clause to return valid empty form data

### DIFF
--- a/javascript/test/utils.serializeForm.test.js
+++ b/javascript/test/utils.serializeForm.test.js
@@ -4,6 +4,14 @@ import { serializeForm } from '../utils'
 
 describe('formSerialize', () => {
   context('basic', () => {
+    it('should output an empty string if no form is present', () => {
+      const dom = new JSDOM('<div></div>')
+      const form = dom.window.document.querySelector('form')
+      const actual = serializeForm(form, { w: dom.window })
+      const expected = ''
+      assert.deepStrictEqual(actual, expected)
+    })
+
     it('should serialize empty form', () => {
       const dom = new JSDOM('<form></form>')
       const form = dom.window.document.querySelector('form')

--- a/javascript/utils.js
+++ b/javascript/utils.js
@@ -12,6 +12,8 @@ export const uuidv4 = () => {
 }
 
 export const serializeForm = (form, options = {}) => {
+  if (!form) return ''
+
   const w = options.w || window
   const { element } = options
 


### PR DESCRIPTION
# Bug fix

## Description

After a lot of headache @marcoroth and me found out that `new FormData(null)` throws an error in Chrome, but does not in safari.

The `closest('form')` call in `stimulate` would return `null` in case no form is present up the DOM hierarchy, blowing up `serializeForm`, but just on Chrome 😂 


## Checklist

- [X] My code follows the style guidelines of this project
- [X] Checks (StandardRB & Prettier-Standard) are passing
- [X] This is not a documentation update
