### PR TITLE
Update package.json to 3.4.0-pre2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stimulus_reflex",
-  "version": "3.3.0",
+  "version": "3.4.0-pre2",
   "description": "Build reactive applications with the Rails tooling you already know and love.",
   "keywords": [
     "ruby",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1534,10 +1534,10 @@ builtin-modules@^3.1.0:
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.1.0.tgz#aad97c15131eb76b65b50ef208e7584cd76a7484"
   integrity sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==
 
-cable_ready@^4.4.0-pre0:
-  version "4.4.0-pre1"
-  resolved "https://registry.yarnpkg.com/cable_ready/-/cable_ready-4.4.0-pre1.tgz#b9a262cefb539a9a87bd71da56835a7ba7d93653"
-  integrity sha512-V71BpFB9Q9KCHEWH3kzz3umaFpafMb7khr3TTZclO1xnepwPTiWgWEMqSv2afaQlPtqH6FEpr0UNK6dH4GwrSA==
+cable_ready@^4.4.0-pre2:
+  version "4.4.0-pre2"
+  resolved "https://registry.yarnpkg.com/cable_ready/-/cable_ready-4.4.0-pre2.tgz#8a970f9117425c5346218a900e24b74fd5d1ddea"
+  integrity sha512-p1PVlVpGW7WVQNrttcaStJ1c+wuoG4fRuyoJJ7hAloZPQu2koPpeO0R48J+iomq4ZRfOmCGTe6I49r/cg/8DJw==
   dependencies:
     morphdom "^2.6.1"
 
@@ -2694,11 +2694,6 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
-
-"form-serialize@>= 0.7.2":
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/form-serialize/-/form-serialize-0.7.2.tgz#b0a2ff0c22026fb6d3d15c9d33f6de6a432e4732"
-  integrity sha1-sKL/DCICb7bT0VydM/beakMuRzI=
 
 fs-extra@8.1.0:
   version "8.1.0"


### PR DESCRIPTION
# Type of PR
Bug Fix

## Description

Bump version in `package.json` also to `3.4.0-pre2`.

## Why should this be added

Apps using StimulusReflex `> 3.3` with linked npm packages to GitHub will crash due to the introduced check in #318. Unless you set `StimulusReflex.config.exit_on_failed_sanity_checks = false`.

```
❯ rails s                                                                                                                                                                    
=> Booting Puma
=> Rails 6.0.3.4 application starting in development
=> Run `rails server --help` for more startup options
WARNING:
The Stimulus Reflex javascript package version (3.3.0) does not match the Rubygem version (3.4.0-pre2).
To update the Stimulus Reflex npm package:
    yarn upgrade stimulus_reflex@3.4.0-pre2

If you know what you are doing and you want to start the application anyway,
you can add the following directive to an initializer:
      StimulusReflex.config.exit_on_failed_sanity_checks = false
Exiting
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update