### PR TITLE
Allow to supress warnings for sanity checks

### DIFF
--- a/lib/generators/stimulus_reflex/templates/config/initializers/stimulus_reflex.rb
+++ b/lib/generators/stimulus_reflex/templates/config/initializers/stimulus_reflex.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 StimulusReflex.configure do |config|
-  # Enable/disable whether startup should be aborted when the sanity checks fail
-  # config.exit_on_failed_sanity_checks = true
+  # Enable/disable exiting / warning when the sanity checks fail options:
+  # `:exit` or `:warn` or `:ignore`
+  # config.on_failed_sanity_checks = true
 
   # Override the parent class that the StimulusReflex ActionCable channel inherits from
   # config.parent_channel = "ApplicationCable::Channel"

--- a/lib/generators/stimulus_reflex/templates/config/initializers/stimulus_reflex.rb
+++ b/lib/generators/stimulus_reflex/templates/config/initializers/stimulus_reflex.rb
@@ -3,7 +3,7 @@
 StimulusReflex.configure do |config|
   # Enable/disable exiting / warning when the sanity checks fail options:
   # `:exit` or `:warn` or `:ignore`
-  # config.on_failed_sanity_checks = true
+  # config.on_failed_sanity_checks = :exit
 
   # Override the parent class that the StimulusReflex ActionCable channel inherits from
   # config.parent_channel = "ApplicationCable::Channel"

--- a/lib/stimulus_reflex/configuration.rb
+++ b/lib/stimulus_reflex/configuration.rb
@@ -14,10 +14,10 @@ module StimulusReflex
   end
 
   class Configuration
-    attr_accessor :exit_on_failed_sanity_checks, :parent_channel
+    attr_accessor :on_failed_sanity_checks, :parent_channel
 
     def initialize
-      @exit_on_failed_sanity_checks = true
+      @on_failed_sanity_checks = :exit
       @parent_channel = "ApplicationCable::Channel"
     end
   end

--- a/lib/stimulus_reflex/sanity_checker.rb
+++ b/lib/stimulus_reflex/sanity_checker.rb
@@ -81,6 +81,10 @@ class StimulusReflex::SanityChecker
   def package_json_path
     Rails.root.join("node_modules", "stimulus_reflex", "package.json")
   end
+  
+  def initializer_path
+    @_initializer_path ||= Rails.root.join("config", "initializers", "stimulus_reflex.rb")
+  end
 
   def warn_and_exit(text)
     puts "WARNING:"
@@ -90,11 +94,38 @@ class StimulusReflex::SanityChecker
 
   def exit_with_info
     puts
-    puts <<~INFO
-      If you know what you are doing and you want to start the application anyway,
-      you can add the following directive to an initializer:
-            StimulusReflex.config.on_failed_sanity_checks = :warn
-    INFO
+    
+    # bundle exec rails generate stimulus_reflex:config
+    if File.exist?(initializer_path)
+      puts <<~INFO
+        If you know what you are doing and you want to start the application anyway,
+        you can add the following directive to the StimulusReflex initializer,
+        which is located at #{initializer_path}
+
+          StimulusReflex.configure do |config|
+            config.on_failed_sanity_checks = :warn
+          end
+
+      INFO
+    else
+      puts <<~INFO
+        If you know what you are doing and you want to start the application anyway,
+        you can create a StimulusReflex initializer with the command:
+      
+        bundle exec rails generate stimulus_reflex:config
+      
+        Then open your initializer at
+      
+        <RAILS_ROOT>/config/initializers/stimulus_reflex.rb
+      
+        and then add the following directive:
+
+          StimulusReflex.configure do |config|
+            config.on_failed_sanity_checks = :warn
+          end
+
+      INFO
+    end
     exit
   end
 end

--- a/lib/stimulus_reflex/sanity_checker.rb
+++ b/lib/stimulus_reflex/sanity_checker.rb
@@ -81,7 +81,7 @@ class StimulusReflex::SanityChecker
   def package_json_path
     Rails.root.join("node_modules", "stimulus_reflex", "package.json")
   end
-  
+
   def initializer_path
     @_initializer_path ||= Rails.root.join("config", "initializers", "stimulus_reflex.rb")
   end
@@ -94,7 +94,7 @@ class StimulusReflex::SanityChecker
 
   def exit_with_info
     puts
-    
+
     # bundle exec rails generate stimulus_reflex:config
     if File.exist?(initializer_path)
       puts <<~INFO

--- a/lib/stimulus_reflex/sanity_checker.rb
+++ b/lib/stimulus_reflex/sanity_checker.rb
@@ -4,6 +4,8 @@ class StimulusReflex::SanityChecker
   JSON_VERSION_FORMAT = /(\d+\.\d+\.\d+.*)"/
 
   def self.check!
+    return if StimulusReflex.config.on_failed_sanity_checks == :ignore
+
     instance = new
     instance.check_caching_enabled
     instance.check_javascript_package_version
@@ -83,7 +85,7 @@ class StimulusReflex::SanityChecker
   def warn_and_exit(text)
     puts "WARNING:"
     puts text
-    exit_with_info if StimulusReflex.config.exit_on_failed_sanity_checks
+    exit_with_info if StimulusReflex.config.on_failed_sanity_checks == :exit
   end
 
   def exit_with_info
@@ -91,7 +93,7 @@ class StimulusReflex::SanityChecker
     puts <<~INFO
       If you know what you are doing and you want to start the application anyway,
       you can add the following directive to an initializer:
-            StimulusReflex.config.exit_on_failed_sanity_checks = false
+            StimulusReflex.config.on_failed_sanity_checks = :warn
     INFO
     exit
   end


### PR DESCRIPTION
# Enhancement

## Description

Changes `confg.exit_on_failed_sanity_checks` that uses a boolean, to `config.on_failed_sanity_checks` with three options `:exit`, `:warn`, `:ignore`

Some people were seeing the warning on test runs, which can be annoying especially if you are working with TDD. So it would be better to provide an opt out possibility.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update
