### PR TITLE
xpath fix

### DIFF
--- a/javascript/utils.js
+++ b/javascript/utils.js
@@ -76,9 +76,9 @@ export const emitEvent = (event, detail) => {
 }
 
 // construct a valid xPath for an element in the DOM
-const computeXPath = element => {
+export const elementToXPath = element => {
   if (element.id !== '') return "//*[@id='" + element.id + "']"
-  if (element === document.body) return 'body'
+  if (element === document.body) return '/html/body'
 
   let ix = 0
   const siblings = element.parentNode.childNodes
@@ -96,12 +96,6 @@ const computeXPath = element => {
       ix++
     }
   }
-}
-
-// if element has an id, pass directly; otherwise, prepend /html/
-export const elementToXPath = element => {
-  const xpath = computeXPath(element)
-  return xpath.startsWith('//*') ? xpath : '/html/' + xpath
 }
 
 export const xPathToElement = xpath => {


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bug fix

## Description

When isolation mode is off and you have multiple tabs on the same page, right now Reflex controllers placed on elements that don't have `id` attributes (or aren't on the body tag) will likely fail due to a malformed xpath string.

Intermediate fix is to put an id on the element with the Stimulus controller which called `stimulate`.

## Why should this be added

People who turn off isolation mode will be sad.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update
