### PR TITLE
fix: revert CR and @rails/actioncable to dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     stimulus_reflex (3.4.0.pre3)
+      cable_ready (>= 4.3.0)
       nokogiri
       rack
       rails (>= 5.2)
@@ -176,7 +177,6 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 2.0)
-  cable_ready (>= 4.3.0)
   pry
   pry-nav
   rake

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -42,17 +42,17 @@
     "dev": "microbundle watch --target browser --format modern,es,cjs --no-strict"
   },
   "peerDependencies": {
-    "@rails/actioncable": ">= 6.0",
-    "cable_ready": ">= 4.3.0",
     "stimulus": ">= 1.1"
+  },
+  "dependencies": {
+    "@rails/actioncable": ">= 6.0",
+    "cable_ready": ">= 4.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.6.2",
     "@babel/preset-env": "^7.6.2",
     "@babel/register": "^7.6.2",
-    "@rails/actioncable": "^6.0.3-3",
     "assert": "^2.0.0",
-    "cable_ready": "^4.4.0-pre0",
     "esm": "^3.2.25",
     "jsdom": "^16.0.1",
     "microbundle": "^0.12.3",

--- a/javascript/yarn.lock
+++ b/javascript/yarn.lock
@@ -1023,10 +1023,10 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
-"@rails/actioncable@^6.0.3-3":
-  version "6.0.3-4"
-  resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-6.0.3-4.tgz#f17c0ef2235d1624d6052b749005608260bd55ef"
-  integrity sha512-uie5McTpl69vHnXCVzKj7iYpVKFfLuE7aqul/I7MX5zVd+yVyyC/g75T1Q10GofyqHYNYWgPiIxgQIoYPyyeKw==
+"@rails/actioncable@>= 6.0":
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-6.0.3.tgz#722b4b639936129307ddbab3a390f6bcacf3e7bc"
+  integrity sha512-I01hgqxxnOgOtJTGlq0ZsGJYiTEEiSGVEGQn3vimZSqEP1HqzyFNbzGTq14Xdyeow2yGJjygjoFF1pmtE+SQaw==
 
 "@rollup/plugin-alias@^3.1.1":
   version "3.1.1"
@@ -1534,10 +1534,10 @@ builtin-modules@^3.1.0:
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.1.0.tgz#aad97c15131eb76b65b50ef208e7584cd76a7484"
   integrity sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==
 
-cable_ready@^4.4.0-pre0:
-  version "4.4.0-pre2"
-  resolved "https://registry.yarnpkg.com/cable_ready/-/cable_ready-4.4.0-pre2.tgz#8a970f9117425c5346218a900e24b74fd5d1ddea"
-  integrity sha512-p1PVlVpGW7WVQNrttcaStJ1c+wuoG4fRuyoJJ7hAloZPQu2koPpeO0R48J+iomq4ZRfOmCGTe6I49r/cg/8DJw==
+"cable_ready@>= 4.3.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/cable_ready/-/cable_ready-4.3.0.tgz#69c6c6963a60d7891f43c7530e343007a00a50b3"
+  integrity sha512-/hjwgdwMoe2hE5KKunsuWXDTr26GzwR7CovdFKHdSHD/yZTFFIv/eY27slMiXUEb57X12GHdliSM59rftTKpoQ==
   dependencies:
     morphdom "^2.6.1"
 

--- a/lib/tasks/stimulus_reflex/install.rake
+++ b/lib/tasks/stimulus_reflex/install.rake
@@ -6,10 +6,9 @@ require "stimulus_reflex/version"
 namespace :stimulus_reflex do
   desc "Install StimulusReflex in this application"
   task install: :environment do
-    system "bundle add cable_ready"
     system "bundle exec rails webpacker:install:stimulus"
     gem_version = StimulusReflex::VERSION.gsub(".pre", "-pre")
-    system "yarn add cable_ready stimulus_reflex@#{gem_version}"
+    system "yarn add stimulus_reflex@#{gem_version}"
     main_folder = defined?(Webpacker) ? Webpacker.config.source_path.to_s.gsub("#{Rails.root}/", "") : "app/javascript"
 
     FileUtils.mkdir_p Rails.root.join("#{main_folder}/controllers"), verbose: true

--- a/package.json
+++ b/package.json
@@ -42,17 +42,17 @@
     "dev": "microbundle watch --target browser --format modern,es,cjs --no-strict"
   },
   "peerDependencies": {
-    "@rails/actioncable": ">= 6.0",
-    "cable_ready": ">= 4.3.0",
     "stimulus": ">= 1.1"
+  },
+  "dependencies": {
+    "@rails/actioncable": ">= 6.0",
+    "cable_ready": ">= 4.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.6.2",
     "@babel/preset-env": "^7.6.2",
     "@babel/register": "^7.6.2",
-    "@rails/actioncable": "^6.0.3-3",
     "assert": "^2.0.0",
-    "cable_ready": "^4.4.0-pre2",
     "esm": "^3.2.25",
     "jsdom": "^16.0.1",
     "microbundle": "^0.12.3",

--- a/stimulus_reflex.gemspec
+++ b/stimulus_reflex.gemspec
@@ -30,9 +30,9 @@ Gem::Specification.new do |gem|
   gem.add_dependency "nokogiri"
   gem.add_dependency "rails", ">= 5.2"
   gem.add_dependency "redis"
+  gem.add_dependency "cable_ready", ">= 4.3.0"
 
   gem.add_development_dependency "bundler", "~> 2.0"
-  gem.add_development_dependency "cable_ready", ">= 4.3.0"
   gem.add_development_dependency "pry-nav"
   gem.add_development_dependency "pry"
   gem.add_development_dependency "rake"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1023,10 +1023,10 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
-"@rails/actioncable@^6.0.3-3":
-  version "6.0.3-4"
-  resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-6.0.3-4.tgz#f17c0ef2235d1624d6052b749005608260bd55ef"
-  integrity sha512-uie5McTpl69vHnXCVzKj7iYpVKFfLuE7aqul/I7MX5zVd+yVyyC/g75T1Q10GofyqHYNYWgPiIxgQIoYPyyeKw==
+"@rails/actioncable@>= 6.0":
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-6.0.3.tgz#722b4b639936129307ddbab3a390f6bcacf3e7bc"
+  integrity sha512-I01hgqxxnOgOtJTGlq0ZsGJYiTEEiSGVEGQn3vimZSqEP1HqzyFNbzGTq14Xdyeow2yGJjygjoFF1pmtE+SQaw==
 
 "@rollup/plugin-alias@^3.1.1":
   version "3.1.1"
@@ -1534,10 +1534,10 @@ builtin-modules@^3.1.0:
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.1.0.tgz#aad97c15131eb76b65b50ef208e7584cd76a7484"
   integrity sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==
 
-cable_ready@^4.4.0-pre2:
-  version "4.4.0-pre2"
-  resolved "https://registry.yarnpkg.com/cable_ready/-/cable_ready-4.4.0-pre2.tgz#8a970f9117425c5346218a900e24b74fd5d1ddea"
-  integrity sha512-p1PVlVpGW7WVQNrttcaStJ1c+wuoG4fRuyoJJ7hAloZPQu2koPpeO0R48J+iomq4ZRfOmCGTe6I49r/cg/8DJw==
+"cable_ready@>= 4.3.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/cable_ready/-/cable_ready-4.3.0.tgz#69c6c6963a60d7891f43c7530e343007a00a50b3"
+  integrity sha512-/hjwgdwMoe2hE5KKunsuWXDTr26GzwR7CovdFKHdSHD/yZTFFIv/eY27slMiXUEb57X12GHdliSM59rftTKpoQ==
   dependencies:
     morphdom "^2.6.1"
 


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

:bug: fix

This fix revert @rails/actioncable and cable_ready to regular dependencies

This also reverts the `.gemspec` file to reflect the same.

## Description

After chatting with the guys in Discord and doing some further research, it appears CR and ActionCable are simply implementation details and not exposable to the outside world. As a result, it feels safe to revert CR and ActionCable back to regular dependencies and keep Stimulus as a peerDependency since it is extendable.

Heres a longer read on NPM package management that better explains the NPM "contract" and how "isolated" dependencies work.

https://lexi-lambda.github.io/blog/2016/08/24/understanding-the-npm-dependency-model/

## Why should this be added

This fixes issues related to users upgrading. Only people using prerelease will be affected. They simply should remove their current `cable_ready` dependency via `yarn remove cable_ready`. Users should also be safe to remove `cable_ready` from their Gemfile if they did this as well.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update

Please note that the best way to suggest changes or updates to the [documentation](https://docs.stimulusreflex.com) is to [join Discord](https://discord.gg/XveN625) and leave a note in the #docs channel. Any documentation updates posted as PRs cannot be accepted at this time. :heart:
