### PR TITLE
Do not run sanity check on `rails generate stimulus_reflex:config`

### DIFF
--- a/lib/stimulus_reflex/sanity_checker.rb
+++ b/lib/stimulus_reflex/sanity_checker.rb
@@ -3,12 +3,21 @@
 class StimulusReflex::SanityChecker
   JSON_VERSION_FORMAT = /(\d+\.\d+\.\d+.*)"/
 
-  def self.check!
-    return if StimulusReflex.config.on_failed_sanity_checks == :ignore
+  class << self
+    def check!
+      return if StimulusReflex.config.on_failed_sanity_checks == :ignore
+      return if called_by_generate_config?
 
-    instance = new
-    instance.check_caching_enabled
-    instance.check_javascript_package_version
+      instance = new
+      instance.check_caching_enabled
+      instance.check_javascript_package_version
+    end
+
+    private
+
+    def called_by_generate_config?
+      ARGV.include? "stimulus_reflex:config"
+    end
   end
 
   def check_caching_enabled


### PR DESCRIPTION
If a sanity check fails, the user gets a hint to create the configuration file with
`rails generate stimulus_reflex:config`, however this command will also fail because it
will also run the sanity check. Therefore we have to bypass the sanity check if
the caller is a `generate_command`.

## Why should this be added

We should add this, as the idea of the whole sanity check is to help people. But if the command we recommend fails, we might be just causing more grief.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update