### PR TITLE
fix nothing morphs and error messages

### DIFF
--- a/javascript/log.js
+++ b/javascript/log.js
@@ -36,6 +36,7 @@ function success (event) {
 function error (event) {
   const { detail } = event || {}
   const { reflexId, target, serverMessage } = detail.stimulusReflex || {}
+  const reflex = reflexes[reflexId]
   const duration = reflex.timestamp
     ? `in ${new Date() - reflex.timestamp}ms`
     : 'CLONED'

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -53,12 +53,13 @@ const createSubscription = controller => {
     actionCableConsumer.subscriptions.create(subscription, {
       received: data => {
         if (!data.cableReady) return
-
-        if (data.operations['dispatchEvent'])
-          return CableReady.perform(data.operations)
-
         let totalOperations = 0
         let reflexData
+
+        if (data.operations['dispatchEvent']) {
+          reflexData = data.operations['dispatchEvent'][0].detail.stimulusReflex
+        }
+
         ;['morph', 'innerHtml'].forEach(operation => {
           if (data.operations[operation] && data.operations[operation].length) {
             if (data.operations[operation][0].stimulusReflex) {


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bug fix

## Description

Nothing morphs need to add a promise to the `reflexes` dictionary or else there's nothing for a non-isolated tab to run.

Also, the `Log#error` function was actually broken since it didn't have an internal handle to the current reflex. Not sure how that slipped past.

Fixes #363 

## Why should this be added

Both bugs are blockers to release.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update

Please note that the best way to suggest changes or updates to the [documentation](https://docs.stimulusreflex.com) is to [join Discord](https://discord.gg/XveN625) and leave a note in the #docs channel. Any documentation updates posted as PRs cannot be accepted at this time. :heart:
