### PR TITLE
Fix fatal error in `stimulus_reflex:install` task with Rails 5.2

### DIFF
--- a/lib/tasks/stimulus_reflex/install.rake
+++ b/lib/tasks/stimulus_reflex/install.rake
@@ -60,7 +60,7 @@ namespace :stimulus_reflex do
       lines.delete_at 1
       lines.insert 1, "  adapter: redis\n"
       lines.insert 2, "  url: <%= ENV.fetch(\"REDIS_URL\") { \"redis://localhost:6379/1\" } %>\n"
-      lines.insert 3, "  channel_prefix: " + Rails.application.class.module_parent.to_s.underscore + "_development\n"
+      lines.insert 3, "  channel_prefix: " + File.basename(Rails.root.to_s).underscore + "_development\n"
       File.open(filepath, "w") { |f| f.write lines.join }
     end
 


### PR DESCRIPTION

# Bug Fix

## Description

Fixes #367

Fixes a fatal error that stops the install task working in Rails 5.2.

The `#module_parent` method doesn't exist in Rails 5.2, but the direct alternatives are deprecated methods in 6.0... The method is only only being used to add a string of the current project's name as a prefix here, so we can switch it for something simple and backwards-compatible.

## Why should this be added

The install works in both versions and you can :fire: the section of the docs that says setting up SR in Rails 5.2 might require some manual hacks...

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update

Please note that the best way to suggest changes or updates to the [documentation](https://docs.stimulusreflex.com) is to [join Discord](https://discord.gg/XveN625) and leave a note in the #docs channel. Any documentation updates posted as PRs cannot be accepted at this time. :heart:
