### PR TITLE
Improve logged post_install.js message

### DIFF
--- a/javascript/scripts/post_install.js
+++ b/javascript/scripts/post_install.js
@@ -1,5 +1,5 @@
 console.log(
-  'Friendly reminder: When updating the stimulus_reflex gem,\n' +
+  'Friendly reminder: When updating the stimulus_reflex package,\n' +
     "don't forget to update your Ruby gem as well.\n\n" +
     'See https://rubygems.org/gems/stimulus_reflex'
 )


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Minor enhancement

## Description

Updates the `javascript/scripts/post_install.js` message to refer to “package” instead of “gem”.

## Why should this be added

Clarifies the logged message (stops confusion) when user updates their ‘stimulus_reflex’ npm package.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update
