### PR TITLE
use puts instead of ActionCable.logger to sidestep silenced AC logs

### DIFF
--- a/app/channels/stimulus_reflex/channel.rb
+++ b/app/channels/stimulus_reflex/channel.rb
@@ -53,7 +53,7 @@ class StimulusReflex::Channel < StimulusReflex.configuration.parent_channel.cons
           reflex.rescue_with_handler(invoke_error)
           reflex.broadcast_message subject: "error", body: body, data: data, error: invoke_error
         else
-          logger.error "\e[31m#{body}\e[0m"
+          puts "\e[31m#{body}\e[0m"
         end
         return
       end
@@ -68,6 +68,7 @@ class StimulusReflex::Channel < StimulusReflex.configuration.parent_channel.cons
           message = exception_message_with_backtrace(render_error)
           body = "Reflex failed to re-render: #{message} [#{url}]"
           reflex.broadcast_message subject: "error", body: body, data: data, error: render_error
+          puts "\e[31m#{body}\e[0m"
         end
       end
     ensure
@@ -109,7 +110,7 @@ class StimulusReflex::Channel < StimulusReflex.configuration.parent_channel.cons
     store.commit_session reflex.request, reflex.controller.response
   rescue => e
     message = "Failed to commit session! #{exception_message_with_backtrace(e)}"
-    logger.error "\e[31m#{message}\e[0m"
+    puts "\e[31m#{message}\e[0m"
   end
 
   def exception_message_with_backtrace(exception)


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Enhancement

## Description

Show Reflex errors on the server even if Reflex fails

## Why should this be added

SR logging is no longer tied to ActionCable logs, which might be silenced.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update

