### PR TITLE
Exit with nonzero status code

### DIFF
--- a/lib/stimulus_reflex/sanity_checker.rb
+++ b/lib/stimulus_reflex/sanity_checker.rb
@@ -135,6 +135,6 @@ class StimulusReflex::SanityChecker
 
       INFO
     end
-    exit
+    exit false
   end
 end


### PR DESCRIPTION
# Enhancement

## Description

The sanity checker should exit with a nonzero status code to indicate failure.

## Why should this be added

While performing system tests in CI, I saw the pipeline go green in a few seconds, because the sanity checker exited with code 0. Ideally, this should raise a red flag instead. I think a nonzero exit code is the correct behavior here.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] Checks (StandardRB & Prettier-Standard) are passing
- [ ] This is not a documentation update

Please note that the best way to suggest changes or updates to the [documentation](https://docs.stimulusreflex.com) is to [join Discord](https://discord.gg/XveN625) and leave a note in the #docs channel. Any documentation updates posted as PRs cannot be accepted at this time. :heart:
