### PR TITLE
fixed bug preventing callbacks for multiple morphs

### DIFF
--- a/javascript/lifecycle.js
+++ b/javascript/lifecycle.js
@@ -126,6 +126,7 @@ document.addEventListener(
 //
 export const dispatchLifecycleEvent = (stage, element, reflexId) => {
   if (!element) return
+  if (!element.reflexData) element.reflexData = {}
   const { target } = element.reflexData[reflexId] || {}
   element.dispatchEvent(
     new CustomEvent(`stimulus-reflex:${stage}`, {

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -70,7 +70,7 @@ const createSubscription = controller => {
               )
               if (urls.length !== 1 || urls[0] !== location.href) return
 
-              totalOperations++
+              totalOperations += data.operations[operation].length
 
               if (!reflexData)
                 reflexData = data.operations[operation][0].stimulusReflex
@@ -95,7 +95,7 @@ const createSubscription = controller => {
 
         if (reflexes[reflexId]) {
           reflexes[reflexId].totalOperations = totalOperations
-          reflexes[reflexId].pendingOperations = 0
+          reflexes[reflexId].pendingOperations = totalOperations
           reflexes[reflexId].completedOperations = 0
           CableReady.perform(data.operations)
         }
@@ -461,9 +461,9 @@ if (!document.stimulusReflexInitialized) {
     const reflex = reflexes[reflexId]
     const promise = reflex.promise
 
-    reflex.pendingOperations++
+    reflex.pendingOperations--
 
-    if (reflex.pendingOperations < reflex.totalOperations) return
+    if (reflex.pendingOperations > 0) return
 
     if (!stimulusReflex.resolveLate)
       setTimeout(() => promise.resolve({ element, event, data: promise.data }))

--- a/lib/stimulus_reflex/broadcasters/broadcaster.rb
+++ b/lib/stimulus_reflex/broadcasters/broadcaster.rb
@@ -27,7 +27,7 @@ module StimulusReflex
 
     def broadcast_message(subject:, body: nil, data: {}, error: nil)
       logger.error "\e[31m#{body}\e[0m" if subject == "error"
-      @operations << ["document", :dispatch_event]
+      operations << ["document", :dispatch_event]
       cable_ready[stream_name].dispatch_event(
         name: "stimulus-reflex:server-message",
         detail: {

--- a/lib/stimulus_reflex/broadcasters/page_broadcaster.rb
+++ b/lib/stimulus_reflex/broadcasters/page_broadcaster.rb
@@ -11,7 +11,7 @@ module StimulusReflex
       document = Nokogiri::HTML.parse(page_html)
       selectors = selectors.select { |s| document.css(s).present? }
       selectors.each do |selector|
-        @operations << [selector, :morph]
+        operations << [selector, :morph]
         html = document.css(selector).inner_html
         cable_ready[stream_name].morph(
           selector: selector,

--- a/lib/stimulus_reflex/broadcasters/selector_broadcaster.rb
+++ b/lib/stimulus_reflex/broadcasters/selector_broadcaster.rb
@@ -11,7 +11,7 @@ module StimulusReflex
           fragment = Nokogiri::HTML.fragment(html)
           match = fragment.at_css(selector)
           if match.present?
-            @operations << [selector, :morph]
+            operations << [selector, :morph]
             cable_ready[stream_name].morph(
               selector: selector,
               html: match.inner_html,
@@ -22,7 +22,7 @@ module StimulusReflex
               })
             )
           else
-            @operations << [selector, :inner_html]
+            operations << [selector, :inner_html]
             cable_ready[stream_name].inner_html(
               selector: selector,
               html: fragment.to_html,


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bug fix

## Description

This started as an addendum to #377 when it became clear that `dispatchLifecycleEvent` was failing for Reflexes that contained multiple morphs. I realized with some horror that `reflex.totalOperations` was being incorrectly calculated. This was a close call.

During the course of my investigation, I flipped the reflex.pendingOperations to count down instead of up (semantics matter!) and removed the unnecessary `@` symbols from the broadcaster classes.

## Why should this be added

Functioning callbacks are desirable.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update