### PR TITLE
make element.reflexController a dictionary

### DIFF
--- a/javascript/lifecycle.js
+++ b/javascript/lifecycle.js
@@ -14,7 +14,7 @@ import { camelize } from './utils'
 //
 const invokeLifecycleMethod = (stage, element, reflexId) => {
   if (!element || !element.reflexData[reflexId]) return
-  const controller = element.reflexController
+  const controller = element.reflexController[reflexId]
   const reflex = element.reflexData[reflexId].target
   const reflexMethodName = reflex.split('#')[1]
 
@@ -53,7 +53,7 @@ const invokeLifecycleMethod = (stage, element, reflexId) => {
   }
 
   if (reflexes[reflexId] && stage === reflexes[reflexId].finalStage) {
-    delete element.reflexController
+    delete element.reflexController[reflexId]
     delete element.reflexData[reflexId]
     delete element.reflexError
     delete reflexes[reflexId]
@@ -134,7 +134,7 @@ export const dispatchLifecycleEvent = (stage, element, reflexId) => {
       cancelable: false,
       detail: {
         reflex: target,
-        controller: element.reflexController,
+        controller: element.reflexController[reflexId],
         reflexId
       }
     })

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -83,8 +83,11 @@ const createSubscription = controller => {
         if (!reflexes[reflexId] && !isolationMode) {
           const element = xPathToElement(reflexData.xpath)
           const controllerElement = xPathToElement(reflexData.cXpath)
-          if (element.reflexController == undefined) element.reflexController = {}
-          element.reflexController[reflexId] = stimulusApplication.getControllerForElementAndIdentifier(
+          if (element.reflexController == undefined)
+            element.reflexController = {}
+          element.reflexController[
+            reflexId
+          ] = stimulusApplication.getControllerForElementAndIdentifier(
             controllerElement,
             reflexData.reflexController
           )
@@ -205,7 +208,7 @@ const extendStimulusController = controller => {
         throw 'The ActionCable channel subscription for StimulusReflex was rejected.'
 
       // lifecycle setup
-      if (element.reflexController == undefined) element.reflexController = {}    
+      if (element.reflexController == undefined) element.reflexController = {}
       element.reflexController[reflexId] = this
       if (element.reflexData == undefined) element.reflexData = {}
       element.reflexData[reflexId] = data

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -83,7 +83,8 @@ const createSubscription = controller => {
         if (!reflexes[reflexId] && !isolationMode) {
           const element = xPathToElement(reflexData.xpath)
           const controllerElement = xPathToElement(reflexData.cXpath)
-          element.reflexController = stimulusApplication.getControllerForElementAndIdentifier(
+          if (element.reflexController == undefined) element.reflexController = {}
+          element.reflexController[reflexId] = stimulusApplication.getControllerForElementAndIdentifier(
             controllerElement,
             reflexData.reflexController
           )
@@ -204,7 +205,8 @@ const extendStimulusController = controller => {
         throw 'The ActionCable channel subscription for StimulusReflex was rejected.'
 
       // lifecycle setup
-      element.reflexController = this
+      if (element.reflexController == undefined) element.reflexController = {}    
+      element.reflexController[reflexId] = this
       if (element.reflexData == undefined) element.reflexData = {}
       element.reflexData[reflexId] = data
 


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

bug fix

## Description

Following up on #377, this PR makes element.reflexController a dictionary to prevent multiple reflexes on the same element from overwriting eachothers' data

Fixes # (issue)

## Why should this be added

prevents race conditions when running multiple reflexes on the same element

## Checklist

- [X] My code follows the style guidelines of this project
- [X] Checks (StandardRB & Prettier-Standard) are passing
- [X] This is not a documentation update

Please note that the best way to suggest changes or updates to the [documentation](https://docs.stimulusreflex.com) is to [join Discord](https://discord.gg/XveN625) and leave a note in the #docs channel. Any documentation updates posted as PRs cannot be accepted at this time. :heart:
