### PR TITLE
Update discourse link

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Stop by #newcomers and introduce yourselves!
 
 ## 💙 Support
 
-Your best bet is to ask for help on Discord before filing an issue on Github. We are happy to help, and we ask people to come with all relevant code to look at. A git repo is preferred, but Gists or posts on [Discourse](https://stimulus-reflex.discourse.group) are fine, too.
+Your best bet is to ask for help on Discord before filing an issue on Github. We are happy to help, and we ask people to come with all relevant code to look at. A git repo is preferred, but Gists or posts on [Discourse](https://discourse.stimulusjs.org/) are fine, too.
 
 Please note that we are not actively providing support on Stack Overflow. If you post there, we likely won't see it.
 


### PR DESCRIPTION
# Fix Link

## Description

Fix link to the discourse link. 

## Why should this be added

I know it is a documentation update. But i do not like broken links..

## Checklist

- [x] My code follows the style guidelines of this project
- [X] Checks (StandardRB & Prettier-Standard) are passing
- [ ] This is not a documentation update 

Please note that the best way to suggest changes or updates to the [documentation](https://docs.stimulusreflex.com) is to [join Discord](https://discord.gg/XveN625) and leave a note in the #docs channel. Any documentation updates posted as PRs cannot be accepted at this time. :heart:
