### PR TITLE
don't show findElement warnings unless debugging

### DIFF
--- a/javascript/attributes.js
+++ b/javascript/attributes.js
@@ -108,7 +108,7 @@ export const extractDataAttributes = element => {
 // SEE: StimulusReflex::Channel#broadcast_morph
 // SEE: StimulusReflex::Channel#broadcast_error
 //
-export const findElement = attributes => {
+export const findElement = (attributes, debugging) => {
   attributes = attributes || {}
   let elements = []
   let selectors = []
@@ -132,21 +132,22 @@ export const findElement = attributes => {
     try {
       elements = document.querySelectorAll(selectors.join(''))
     } catch (error) {
-      console.error(
-        'StimulusReflex encountered an error identifying the Stimulus element. Consider adding an #id to the element.',
-        error,
-        { 'CSS selector': selectors.join(''), attributes }
-      )
+      if (debugging)
+        console.error(
+          'StimulusReflex encountered an error identifying the Stimulus element. Consider adding an #id to the element.',
+          error,
+          { 'CSS selector': selectors.join(''), attributes }
+        )
     }
   }
 
-  if (elements.length === 0)
+  if (debugging && elements.length === 0)
     console.warn(
       'StimulusReflex was unable to find an element that matches the signature of the element which triggered this Reflex. Lifecycle callbacks and events cannot be raised unless your elements have distinguishing characteristics. Consider adding an #id or a randomized data-key to the element.',
       { 'CSS selector': selectors.join(''), attributes }
     )
 
-  if (elements.length > 1)
+  if (debugging && elements.length > 1)
     console.warn(
       'StimulusReflex found multiple identical elements that match the signature of the element which triggered this Reflex. Lifecycle callbacks and events cannot be raised unless your elements have distinguishing characteristics. Consider adding an #id or a randomized data-key to the element.',
       { 'CSS selector': selectors.join(''), attributes }

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -463,7 +463,7 @@ if (!document.stimulusReflexInitialized) {
     const { stimulusReflex } = event.detail || {}
     if (!stimulusReflex) return
     const { reflexId, attrs } = stimulusReflex
-    const element = findElement(attrs)
+    const element = findElement(attrs, debugging)
     const reflex = reflexes[reflexId]
     const promise = reflex.promise
 
@@ -484,7 +484,7 @@ if (!document.stimulusReflexInitialized) {
     const { stimulusReflex } = event.detail || {}
     if (!stimulusReflex) return
     const { reflexId, attrs } = stimulusReflex
-    const element = findElement(attrs)
+    const element = findElement(attrs, debugging)
     const reflex = reflexes[reflexId]
     const promise = reflex.promise
 
@@ -506,7 +506,7 @@ if (!document.stimulusReflexInitialized) {
   document.addEventListener('stimulus-reflex:server-message', event => {
     const { reflexId, attrs, serverMessage } = event.detail.stimulusReflex || {}
     const { subject, body } = serverMessage
-    const element = findElement(attrs)
+    const element = findElement(attrs, debugging)
     const promise = reflexes[reflexId].promise
     const subjects = { error: true, halted: true, nothing: true, success: true }
 


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Enhancement

## Description

This PR passes the current value of `debugging` into `findElement` as a second parameter and updates all references to it to pass `debugging`.

## Why should this be added

@dsazup pointed out that receiving warnings when SR can't find an element is problematic for end users. Developer happiness != user happiness.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update