### PR TITLE
split SR operations from data.operations

### DIFF
--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -69,7 +69,7 @@ const createSubscription = controller => {
                 data.operations[name].splice(i, 1)
               }
             }
-            if (data.operations[name].length == 0)
+            if (!data.operations[name].length)
               Reflect.deleteProperty(data.operations, name)
           }
         }

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -54,12 +54,34 @@ const createSubscription = controller => {
       received: data => {
         if (!data.cableReady) return
 
+        let reflexOperations = {}
+
+        for (let name in data.operations) {
+          if (data.operations.hasOwnProperty(name)) {
+            for (let i = data.operations[name].length - 1; i >= 0; i--) {
+              if (
+                data.operations[name][i].stimulusReflex ||
+                (data.operations[name][i].detail &&
+                  data.operations[name][i].detail.stimulusReflex)
+              ) {
+                if (!reflexOperations[name]) reflexOperations[name] = []
+                reflexOperations[name].push(data.operations[name][i])
+                data.operations[name].splice(i, 1)
+              }
+            }
+            if (data.operations[name].length == 0)
+              Reflect.deleteProperty(data.operations, name)
+          }
+        }
+
+        CableReady.perform(data.operations)
+
         let totalOperations = 0
         let reflexData
 
-        const dispatchEvent = data.operations['dispatchEvent']
-        const morph = data.operations['morph']
-        const innerHtml = data.operations['innerHtml']
+        const dispatchEvent = reflexOperations['dispatchEvent']
+        const morph = reflexOperations['morph']
+        const innerHtml = reflexOperations['innerHtml']
 
         ;[dispatchEvent, morph, innerHtml].forEach(operation => {
           if (operation && operation.length && operation[0].stimulusReflex) {
@@ -101,9 +123,9 @@ const createSubscription = controller => {
             reflexes[reflexId].totalOperations = totalOperations
             reflexes[reflexId].pendingOperations = totalOperations
             reflexes[reflexId].completedOperations = 0
-            CableReady.perform(data.operations)
+            CableReady.perform(reflexOperations)
           }
-        } else CableReady.perform(data.operations)
+        }
       },
       connected: () => {
         actionCableSubscriptionActive = true


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bug fix

## Description

Core conversation about whether to encourage `broadcast` or not in #382 led to me [realizing](https://github.com/hopsoft/stimulus_reflex/pull/382#issuecomment-734821300) that our fancy new operations handling scheme would fall over if someone tried to blend SR + non-SR operations in one payload.

Notable things:

- I used `Reflect.deleteProperty` for the first time, because it turns out that you can't force an object to dereference a key. Lodash used to work with a shallow copy to address this, ECMA2015 fixed it. **This might need to be Polyfilled for IE11** @marcoroth 

- I tried to act like I've been doing this a long time and counted down from the top of each operations array so that I could slice out individual elements and not create an index error like a noob

I've tested this with and without `broadcast` on the end of the chain and it works well so far as I can tell. My test case had two SR morphs + a CR `console_log` operation.

## Why should this be added

SR client needs to be robust even when users don't follow best practices advice.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update
