### PR TITLE
dont exit in sanity checker on `stimulus_reflex:install`

### DIFF
--- a/lib/stimulus_reflex/sanity_checker.rb
+++ b/lib/stimulus_reflex/sanity_checker.rb
@@ -6,6 +6,7 @@ class StimulusReflex::SanityChecker
   class << self
     def check!
       return if StimulusReflex.config.on_failed_sanity_checks == :ignore
+      return if called_by_installer?
       return if called_by_generate_config?
 
       instance = new
@@ -14,6 +15,12 @@ class StimulusReflex::SanityChecker
     end
 
     private
+
+    def called_by_installer?
+      Rake.application.top_level_tasks.include? "stimulus_reflex:install"
+    rescue
+      false
+    end
 
     def called_by_generate_config?
       ARGV.include? "stimulus_reflex:config"
@@ -120,13 +127,13 @@ class StimulusReflex::SanityChecker
       puts <<~INFO
         If you know what you are doing and you want to start the application anyway,
         you can create a StimulusReflex initializer with the command:
-      
+
         bundle exec rails generate stimulus_reflex:config
-      
+
         Then open your initializer at
-      
+
         <RAILS_ROOT>/config/initializers/stimulus_reflex.rb
-      
+
         and then add the following directive:
 
           StimulusReflex.configure do |config|


### PR DESCRIPTION
# Type of PR

Bug Fix

## Description

I just noticed, that when you create an new Rails app with the current master ([`45e12ed`](https://github.com/hopsoft/stimulus_reflex/commit/45e12ede8a75ccb90270210dcc4a606122efd874)), that the sanity checker kicks in and aborts the `rails stimulus_reflex:install` script because it can't find the `stimulus_reflex` npm package in the `package.json`. This package isn't included yet, because this installer is responsible for adding it in the first place.

/cc @RolandStuder 

## Why should this be added

New users shouldn't be stopped by the sanity check on their first hands-on with StimulusReflex.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update