### PR TITLE
add jQuery support to SR library events

### DIFF
--- a/javascript/lifecycle.js
+++ b/javascript/lifecycle.js
@@ -129,15 +129,11 @@ export const dispatchLifecycleEvent = (stage, element, reflexId) => {
   if (!element.reflexData) element.reflexData = {}
   if (!element.reflexController) element.reflexController = {}
   const { target } = element.reflexData[reflexId] || {}
+  const { controller } = element.reflexController[reflexId] || {}
+  const detail = { reflex: target, controller, reflexId }
+  const event = `stimulus-reflex:${stage}`
   element.dispatchEvent(
-    new CustomEvent(`stimulus-reflex:${stage}`, {
-      bubbles: true,
-      cancelable: false,
-      detail: {
-        reflex: target,
-        controller: element.reflexController[reflexId],
-        reflexId
-      }
-    })
+    new CustomEvent(event, { bubbles: true, cancelable: false, detail })
   )
+  if (window.jQuery) window.jQuery(element).trigger(event, detail)
 }

--- a/javascript/utils.js
+++ b/javascript/utils.js
@@ -73,6 +73,7 @@ export const emitEvent = (event, detail) => {
       detail
     })
   )
+  if (window.jQuery) window.jQuery(document).trigger(event, detail)
 }
 
 // construct a valid xPath for an element in the DOM


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Enhancement

## Description

This PR borrows a line from CableReady which makes the library and lifecycle events available to jQuery developers:

- stimulus-reflex:connected
- stimulus-reflex:disconnected
- stimulus-reflex:rejected
- stimulus-reflex:ready

- stimulus-reflex:before
- stimulus-reflex:success
- stimulus-reflex:error
- stimulus-reflex:halted
- stimulus-reflex:after
- stimulus-reflex:finalize

## Why should this be added

We see lots of jQuery developers using StimulusReflex. This change brings SR to parallel jQuery support as already exists in CableReady.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update