### PR TITLE
reflexError and received refactor

### DIFF
--- a/javascript/lifecycle.js
+++ b/javascript/lifecycle.js
@@ -37,7 +37,7 @@ const invokeLifecycleMethod = (stage, element, reflexId) => {
       controller,
       element,
       reflex,
-      element.reflexError,
+      element.reflexError[reflexId],
       reflexId
     )
   }
@@ -47,16 +47,16 @@ const invokeLifecycleMethod = (stage, element, reflexId) => {
       controller,
       element,
       reflex,
-      element.reflexError,
+      element.reflexError[reflexId],
       reflexId
     )
   }
 
   if (reflexes[reflexId] && stage === reflexes[reflexId].finalStage) {
-    delete element.reflexController[reflexId]
-    delete element.reflexData[reflexId]
-    delete element.reflexError
-    delete reflexes[reflexId]
+    Reflect.deleteProperty(element.reflexController, reflexId)
+    Reflect.deleteProperty(element.reflexData, reflexId)
+    Reflect.deleteProperty(element.reflexError, reflexId)
+    Reflect.deleteProperty(reflexes, reflexId)
   }
 }
 

--- a/javascript/lifecycle.js
+++ b/javascript/lifecycle.js
@@ -126,8 +126,8 @@ document.addEventListener(
 //
 export const dispatchLifecycleEvent = (stage, element, reflexId) => {
   if (!element) return
-  if (!element.reflexData) element.reflexData = {}
-  if (!element.reflexController) element.reflexController = {}
+  element.reflexController = element.reflexController || {}
+  element.reflexData = element.reflexData || {}
   const { target } = element.reflexData[reflexId] || {}
   element.dispatchEvent(
     new CustomEvent(`stimulus-reflex:${stage}`, {

--- a/javascript/log.js
+++ b/javascript/log.js
@@ -25,7 +25,7 @@ function success (event) {
     .split('-')
     .slice(1)
     .join('_')
-  const halted = (serverMessage && serverMessage.subject == 'halted') || false
+  const halted = (serverMessage && serverMessage.subject === 'halted') || false
   console.log(
     `\u2193 reflex \u2193 ${target} \u2192 ${selector ||
       '\u221E'}${progress} ${duration}`,

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -84,9 +84,13 @@ const createSubscription = controller => {
         const innerHtml = reflexOperations['innerHtml']
 
         ;[dispatchEvent, morph, innerHtml].forEach(operation => {
-          if (operation && operation.length && operation[0].stimulusReflex) {
+          if (operation && operation.length) {
             const urls = Array.from(
-              new Set(operation.map(m => m.stimulusReflex.url))
+              new Set(
+                operation.map(m =>
+                  m.detail ? m.detail.stimulusReflex.url : m.stimulusReflex.url
+                )
+              )
             )
             if (urls.length !== 1 || urls[0] !== location.href) return
 
@@ -114,6 +118,7 @@ const createSubscription = controller => {
               reflexData.reflexController
             )
             if (element.reflexData == undefined) element.reflexData = {}
+            if (element.reflexError == undefined) element.reflexError = {}
             element.reflexData[reflexId] = reflexData
             dispatchLifecycleEvent('before', element, reflexId)
             registerReflex(reflexData)
@@ -235,6 +240,7 @@ const extendStimulusController = controller => {
       element.reflexController[reflexId] = this
       if (element.reflexData == undefined) element.reflexData = {}
       element.reflexData[reflexId] = data
+      if (element.reflexError == undefined) element.reflexError = {}
 
       dispatchLifecycleEvent('before', element, reflexId)
 
@@ -532,7 +538,7 @@ if (!document.stimulusReflexInitialized) {
     const promise = reflexes[reflexId].promise
     const subjects = { error: true, halted: true, nothing: true, success: true }
 
-    if (element && subject == 'error') element.reflexError = body
+    if (element && subject == 'error') element.reflexError[reflexId] = body
 
     promise[subject == 'error' ? 'reject' : 'resolve']({
       data: promise.data,

--- a/javascript/utils.js
+++ b/javascript/utils.js
@@ -24,8 +24,8 @@ export const serializeForm = (form, options = {}) => {
   if (
     element &&
     element.name &&
-    element.nodeName == 'INPUT' &&
-    element.type == 'submit'
+    element.nodeName === 'INPUT' &&
+    element.type === 'submit'
   ) {
     data.push(`${element.name}=${element.value}`)
   } else if (submitButton && submitButton.name) {


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bug fix + light refactor

## Description

1. convert `delete` calls to use `Reflect.deleteProperty` in `lifecycle.js`
2. modified `element.reflexError` to be an object for concurrency
3. fixed bug in recent `received` method changes to robustly handle Reflex errors

## Why should this be added

1. consistency and resource allocation etiquette
2. should follow the same pattern as `element.reflexData` and `element.reflexController`
3. `dispatchEvent` requires a ternary to test for the presence of a `detail` object

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update

Please note that the best way to suggest changes or updates to the [documentation](https://docs.stimulusreflex.com) is to [join Discord](https://discord.gg/XveN625) and leave a note in the #docs channel. Any documentation updates posted as PRs cannot be accepted at this time. :heart:
