### PR TITLE
`invokeLifecycleMethod()`: handle undefined `element` parameter

### DIFF
--- a/javascript/lifecycle.js
+++ b/javascript/lifecycle.js
@@ -15,6 +15,8 @@ import Debug from './debug'
 // - element - the element that triggered the reflex (not necessarily the Stimulus controller's element)
 //
 const invokeLifecycleMethod = (stage, element, reflexId) => {
+  if (!element || !element.reflexData[reflexId]) return
+
   const controller = element.reflexController[reflexId]
   const reflex = element.reflexData[reflexId].target
   const reflexMethodName = reflex.split('#')[1]


### PR DESCRIPTION
# Type of PR

Bug Fix

## Description

In some situations when you triggered a reflex this error would pop in the console:

<img width="1368" alt="Screenshot 2020-11-30 at 18 25 55" src="https://user-images.githubusercontent.com/6411752/100652347-18668a80-3347-11eb-9b52-93cebd283906.png">

I wasn't able to find an explanation for why and when it exactly happened. But I removed [the line](https://github.com/hopsoft/stimulus_reflex/pull/386/files#diff-1025ac8883ebdd00e6755481d958067ac87d99c5e8e3d3be4e67541cc0ed615aL16) this PR adds in #386 🙈 

## Why should this be added

It seems that everything worked even without this fix, but one potential error less for the user to stumble upon is always better ;)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update