### PR TITLE
Allow StimulusReflex to process Rack middlewares

### DIFF
--- a/app/channels/stimulus_reflex/channel.rb
+++ b/app/channels/stimulus_reflex/channel.rb
@@ -60,18 +60,18 @@ class StimulusReflex::Channel < StimulusReflex.configuration.parent_channel.cons
             initializer_path = Rails.root.join("config", "initializers", "stimulus_reflex.rb")
 
             puts <<~NOTE
-              \e[33mNOTE: It looks like we couldn't re-render the page because we couldn't find a matching route.
-              If you are using rack middleware to rewrite part of the request path make sure you also configured
-              the middleware accordingly in the StimulusReflex initializer.
-              The initializer should be located at #{initializer_path}.
-              If it doesn't exist you can generate it with:
+              \e[33mNOTE: StimulusReflex failed to locate a matching route and could not re-render the page.
+
+              If your app uses Rack middleware to rewrite part of the request path, you must enable those middleware modules in StimulusReflex.
+              The StimulusReflex initializer should be located at #{initializer_path}, or you can generate it with:
 
                 $ bundle exec rails generate stimulus_reflex:config
 
-              Configure the middleware in your initializer:
+              Configure any required middleware:
 
                 StimulusReflex.configure do |config|
-                  config.middleware.use YourRackMiddleware
+                  config.middleware.use FirstRackMiddleware
+                  config.middleware.use SecondRackMiddleware
                 end\e[0m
 
             NOTE

--- a/lib/generators/stimulus_reflex/templates/config/initializers/stimulus_reflex.rb
+++ b/lib/generators/stimulus_reflex/templates/config/initializers/stimulus_reflex.rb
@@ -17,4 +17,10 @@ StimulusReflex.configure do |config|
   # eg. if your connection is `identified_by :current_user` and your User model has an email attribute, you can access r.email (it will display `-` if the user isn't logged in)
 
   # config.logging = proc { "[#{session_id}] #{operation_counter.magenta} #{reflex_info.green} -> #{selector.cyan} via #{mode} Morph (#{operation.yellow})" }
+
+  # Set `process_middleware` to `false` if StimulusReflex shouldn't process
+  # the Rails middleware stack before executing the reflex. This is useful if
+  # you don't need rack middleware processing and want to gain some performance.
+
+  # config.process_middleware = true
 end

--- a/lib/generators/stimulus_reflex/templates/config/initializers/stimulus_reflex.rb
+++ b/lib/generators/stimulus_reflex/templates/config/initializers/stimulus_reflex.rb
@@ -18,9 +18,12 @@ StimulusReflex.configure do |config|
 
   # config.logging = proc { "[#{session_id}] #{operation_counter.magenta} #{reflex_info.green} -> #{selector.cyan} via #{mode} Morph (#{operation.yellow})" }
 
-  # Set `process_middleware` to `false` if StimulusReflex shouldn't process
-  # the Rails middleware stack before executing the reflex. This is useful if
-  # you don't need rack middleware processing and want to gain some performance.
+  # StimulusReflex uses it's own middleware stack. If you need a middleware to
+  # be executed on every reflex register them here. It works the same way as
+  # registering a rack middleware in Rails.
+  #
+  # Learn more about registering rack middleware in Rails here:
+  # https://guides.rubyonrails.org/rails_on_rack.html#configuring-middleware-stack
 
-  # config.process_middleware = true
+  # config.middleware.use YourRackMiddleware
 end

--- a/lib/generators/stimulus_reflex/templates/config/initializers/stimulus_reflex.rb
+++ b/lib/generators/stimulus_reflex/templates/config/initializers/stimulus_reflex.rb
@@ -15,15 +15,15 @@ StimulusReflex.configure do |config|
   # Available colors: red, green, yellow, blue, magenta, cyan, white
   # You can also use attributes from your ActionCable Connection's identifiers that resolve to valid ActiveRecord models
   # eg. if your connection is `identified_by :current_user` and your User model has an email attribute, you can access r.email (it will display `-` if the user isn't logged in)
+  # Learn more at: https://docs.stimulusreflex.com/troubleshooting#stimulusreflex-logging
 
   # config.logging = proc { "[#{session_id}] #{operation_counter.magenta} #{reflex_info.green} -> #{selector.cyan} via #{mode} Morph (#{operation.yellow})" }
 
-  # StimulusReflex uses it's own middleware stack. If you need a middleware to
-  # be executed on every reflex register them here. It works the same way as
-  # registering a rack middleware in Rails.
+  # Optimized for speed, StimulusReflex doesn't enable Rack middleware by default.
+  # If you are using Page Morphs and your app uses Rack middleware to rewrite part of the request path, you must enable those middleware modules in StimulusReflex.
   #
-  # Learn more about registering rack middleware in Rails here:
-  # https://guides.rubyonrails.org/rails_on_rack.html#configuring-middleware-stack
+  # Learn more about registering Rack middleware in Rails here: https://guides.rubyonrails.org/rails_on_rack.html#configuring-middleware-stack
 
-  # config.middleware.use YourRackMiddleware
+  # config.middleware.use FirstRackMiddleware
+  # config.middleware.use SecondRackMiddleware
 end

--- a/lib/stimulus_reflex/configuration.rb
+++ b/lib/stimulus_reflex/configuration.rb
@@ -14,7 +14,7 @@ module StimulusReflex
   end
 
   class Configuration
-    attr_accessor :on_failed_sanity_checks, :parent_channel, :logging
+    attr_accessor :on_failed_sanity_checks, :parent_channel, :logging, :process_middleware
 
     DEFAULT_LOGGING = proc { "[#{session_id}] #{operation_counter.magenta} #{reflex_info.green} -> #{selector.cyan} via #{mode} Morph (#{operation.yellow})" }
 
@@ -22,6 +22,7 @@ module StimulusReflex
       @on_failed_sanity_checks = :exit
       @parent_channel = "ApplicationCable::Channel"
       @logging = DEFAULT_LOGGING
+      @process_middleware = true
     end
   end
 end

--- a/lib/stimulus_reflex/configuration.rb
+++ b/lib/stimulus_reflex/configuration.rb
@@ -14,7 +14,7 @@ module StimulusReflex
   end
 
   class Configuration
-    attr_accessor :on_failed_sanity_checks, :parent_channel, :logging
+    attr_accessor :on_failed_sanity_checks, :parent_channel, :logging, :middlewares
 
     DEFAULT_LOGGING = proc { "[#{session_id}] #{operation_counter.magenta} #{reflex_info.green} -> #{selector.cyan} via #{mode} Morph (#{operation.yellow})" }
 
@@ -22,6 +22,7 @@ module StimulusReflex
       @on_failed_sanity_checks = :exit
       @parent_channel = "ApplicationCable::Channel"
       @logging = DEFAULT_LOGGING
+      @middlewares = []
     end
   end
 end

--- a/lib/stimulus_reflex/configuration.rb
+++ b/lib/stimulus_reflex/configuration.rb
@@ -14,7 +14,7 @@ module StimulusReflex
   end
 
   class Configuration
-    attr_accessor :on_failed_sanity_checks, :parent_channel, :logging, :middlewares
+    attr_accessor :on_failed_sanity_checks, :parent_channel, :logging
 
     DEFAULT_LOGGING = proc { "[#{session_id}] #{operation_counter.magenta} #{reflex_info.green} -> #{selector.cyan} via #{mode} Morph (#{operation.yellow})" }
 
@@ -22,7 +22,6 @@ module StimulusReflex
       @on_failed_sanity_checks = :exit
       @parent_channel = "ApplicationCable::Channel"
       @logging = DEFAULT_LOGGING
-      @middlewares = []
     end
   end
 end

--- a/lib/stimulus_reflex/configuration.rb
+++ b/lib/stimulus_reflex/configuration.rb
@@ -14,7 +14,7 @@ module StimulusReflex
   end
 
   class Configuration
-    attr_accessor :on_failed_sanity_checks, :parent_channel, :logging, :process_middleware
+    attr_accessor :on_failed_sanity_checks, :parent_channel, :logging, :middleware
 
     DEFAULT_LOGGING = proc { "[#{session_id}] #{operation_counter.magenta} #{reflex_info.green} -> #{selector.cyan} via #{mode} Morph (#{operation.yellow})" }
 
@@ -22,7 +22,7 @@ module StimulusReflex
       @on_failed_sanity_checks = :exit
       @parent_channel = "ApplicationCable::Channel"
       @logging = DEFAULT_LOGGING
-      @process_middleware = true
+      @middleware = ActionDispatch::MiddlewareStack.new
     end
   end
 end

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -88,13 +88,11 @@ class StimulusReflex::Reflex
 
       env = connection.env.merge(mock_env)
 
-      if StimulusReflex.config.process_middleware
-        stack = Rails.application.middleware
+      middleware = StimulusReflex.config.middleware
 
-        if stack.respond_to?(:build)
-          stack = stack.build(Rails.application.routes)
-          stack.call(env)
-        end
+      if middleware.any?
+        stack = middleware.build(Rails.application.routes)
+        stack.call(env)
       end
 
       req = ActionDispatch::Request.new(env)

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -88,11 +88,13 @@ class StimulusReflex::Reflex
 
       env = connection.env.merge(mock_env)
 
-      stack = Rails.application.middleware
+      if StimulusReflex.config.process_middleware
+        stack = Rails.application.middleware
 
-      if stack.respond_to?(:build)
-        stack = stack.build(Rails.application.routes)
-        stack.call(env)
+        if stack.respond_to?(:build)
+          stack = stack.build(Rails.application.routes)
+          stack.call(env)
+        end
       end
 
       req = ActionDispatch::Request.new(env)

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -88,8 +88,12 @@ class StimulusReflex::Reflex
 
       env = connection.env.merge(mock_env)
 
-      stack = Rails.application.middleware.build
-      stack.call(env)
+      stack = Rails.application.middleware
+
+      if stack.respond_to?(:build)
+        stack = stack.build
+        stack.call(env)
+      end
 
       req = ActionDispatch::Request.new(env)
 

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -87,6 +87,12 @@ class StimulusReflex::Reflex
       )
 
       env = connection.env.merge(mock_env)
+
+      StimulusReflex.configuration.middlewares.each do |middleware|
+        instance = middleware.new(Rails.application.routes)
+        instance.call(env)
+      end
+
       req = ActionDispatch::Request.new(env)
 
       path_params = Rails.application.routes.recognize_path_with_request(req, url, req.env[:extras] || {})

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -88,10 +88,8 @@ class StimulusReflex::Reflex
 
       env = connection.env.merge(mock_env)
 
-      StimulusReflex.configuration.middlewares.each do |middleware|
-        instance = middleware.new(Rails.application.routes)
-        instance.call(env)
-      end
+      stack = Rails.application.middleware.build
+      stack.call(env)
 
       req = ActionDispatch::Request.new(env)
 

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -91,7 +91,7 @@ class StimulusReflex::Reflex
       stack = Rails.application.middleware
 
       if stack.respond_to?(:build)
-        stack = stack.build
+        stack = stack.build(Rails.application.routes)
         stack.call(env)
       end
 


### PR DESCRIPTION
# Type of PR

Feature / Bug Fix

## Description

This PR allows StimulusReflex to process Rack middlewares. StimulusReflex has it's own middleware stack. You need to declare which middlewares you want StimulusReflex to process on every reflex. 

It works the same way as registering a rack middleware in Rails. All the methods are available, have a look at the [docs here](https://guides.rubyonrails.org/rails_on_rack.html#configuring-middleware-stack). 

In the example of #289 the initializer would look like this: 

```ruby
StimulusReflex.configure do |config|
  config.middleware.use AccountSlug::Extractor
end
```

Fixes #289

## Why should this be added

Any Rack middleware used in a Rails app isn't currently processed by StimulusReflex when you trigger a reflex. This could break some existing advanced apps which for example do request rewriting in a Rack middleware.

/cc @dixpac, @excid3, @leastbad 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update
