### PR TITLE
Fix multiple broadcasts from within the same reflex

### DIFF
--- a/lib/stimulus_reflex/cable_ready_channels.rb
+++ b/lib/stimulus_reflex/cable_ready_channels.rb
@@ -1,12 +1,21 @@
+# frozen_string_literal: true
+
 module StimulusReflex
   class CableReadyChannels
     stimulus_reflex_channel_methods = CableReady::Channels.instance.operations.keys + [:broadcast, :broadcast_to]
-    delegate(*stimulus_reflex_channel_methods, to: "@stimulus_reflex_channel")
-    delegate :[], to: "@cable_ready_channels"
+    delegate(*stimulus_reflex_channel_methods, to: "stimulus_reflex_channel")
+    delegate :[], to: "cable_ready_channels"
 
     def initialize(stream_name)
-      @cable_ready_channels = CableReady::Channels.instance
-      @stimulus_reflex_channel = @cable_ready_channels[stream_name]
+      @stream_name = stream_name
+    end
+
+    def cable_ready_channels
+      CableReady::Channels.instance
+    end
+
+    def stimulus_reflex_channel
+      CableReady::Channels.instance[@stream_name]
     end
   end
 end

--- a/stimulus_reflex.gemspec
+++ b/stimulus_reflex.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../lib/stimulus_reflex/version", __FILE__)
 
 Gem::Specification.new do |gem|

--- a/test/broadcasters/broadcaster_test.rb
+++ b/test/broadcasters/broadcaster_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "broadcaster_test_case"
 
 class StimulusReflex::BroadcasterTest < StimulusReflex::BroadcasterTestCase

--- a/test/broadcasters/broadcaster_test_case.rb
+++ b/test/broadcasters/broadcaster_test_case.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../test_helper"
 
 class StimulusReflex::BroadcasterTestCase < ActionCable::Channel::TestCase

--- a/test/broadcasters/nothing_broadcaster_test.rb
+++ b/test/broadcasters/nothing_broadcaster_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "broadcaster_test_case"
 
 class StimulusReflex::NothingBroadcasterTest < StimulusReflex::BroadcasterTestCase

--- a/test/broadcasters/page_broadcaster_test.rb
+++ b/test/broadcasters/page_broadcaster_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "broadcaster_test_case"
 
 class StimulusReflex::PageBroadcasterTest < StimulusReflex::BroadcasterTestCase

--- a/test/broadcasters/selector_broadcaster_test.rb
+++ b/test/broadcasters/selector_broadcaster_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # require_relative "broadcaster_test_case"
 
 # class StimulusReflex::SelectorBroadcasterTest < StimulusReflex::BroadcasterTestCase

--- a/test/reflex_test.rb
+++ b/test/reflex_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "test_helper"
 
 class StimulusReflex::ReflexTest < ActionCable::Channel::TestCase


### PR DESCRIPTION
# Bug fix

## Description

Don't memoize the singleton `CableReady::Channels.instance` as it causes issues with multiple broadcasts.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update