### PR TITLE
Don't run sanity checker in production

### DIFF
--- a/lib/stimulus_reflex.rb
+++ b/lib/stimulus_reflex.rb
@@ -24,7 +24,7 @@ require "stimulus_reflex/logger"
 module StimulusReflex
   class Engine < Rails::Engine
     initializer "stimulus_reflex.sanity_check" do
-      SanityChecker.check!
+      SanityChecker.check! unless Rails.env.production?
     end
   end
 end


### PR DESCRIPTION
# Enhancement

## Description

This is an anxilliary PR to #403 regarding #402 

I don't think the sanity checker should be running in production at all, and that would be consistent with the sanity checks that Rails and Webpacker perform (migrations, npm dependency checks). I think it's safe to assume that if a user has progressed to production, their code should already be passing the sanity checks.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update

