### PR TITLE
Add dom_id to the reflex

### DIFF
--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -53,6 +53,7 @@ class StimulusReflex::Reflex
   delegate :broadcast, :broadcast_message, to: :broadcaster
   delegate :reflex_id, :reflex_controller, :xpath, :c_xpath, :permanent_attribute_name, to: :client_attributes
   delegate :render, to: :controller_class
+  delegate :dom_id, to: "ActionView::RecordIdentifier"
 
   def initialize(channel, url: nil, element: nil, selectors: [], method_name: nil, params: {}, client_attributes: {})
     @channel = channel

--- a/test/reflex_test.rb
+++ b/test/reflex_test.rb
@@ -25,4 +25,8 @@ class StimulusReflex::ReflexTest < ActionCable::Channel::TestCase
   test "render partial" do
     assert @reflex.render(partial: "/hello_partial", assigns: {message: "Testing 123"}) == "<p>Hello from partial! Testing 123</p>\n"
   end
+
+  test "dom_id" do
+    assert @reflex.dom_id(TestModel.new(id: 123)) == "test_model_123"
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,7 @@ ENV["RAILS_ENV"] ||= "test"
 
 require "minitest/mock"
 require "rails"
+require "active_model"
 require "action_controller"
 require "pry"
 require_relative "../lib/stimulus_reflex"
@@ -32,6 +33,11 @@ class ActionDispatch::Request
   def session
     @session ||= SessionMock.new
   end
+end
+
+class TestModel
+  include ActiveModel::Model
+  attr_accessor :id
 end
 
 StimulusReflex.configuration.parent_channel = "ActionCable::Channel::Base"


### PR DESCRIPTION
# Enhancement

## Description

Expose `dom_id` to the reflex as we will no longer recommend that people include `CableReady::Broadcaster` in their reflexes after 3.4 ships.

## Why should this be added

Convenience and developer happiness.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update