### PR TITLE
Update authentication.md

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -97,7 +97,7 @@ module ApplicationCable
     protected
 
     def find_verified_user
-      if (current_user = env["warden"].user)
+      if (current_user = env["warden"].user(:user))
         current_user
       else
         reject_unauthorized_connection


### PR DESCRIPTION
In case you have multiple Devise User model (eg. Admin and User) you will need to specify :user otherwise is nil.
Reference: https://stackoverflow.com/questions/43258458/envwarden-not-working-with-rails-5