### PR TITLE
dom_id enhancements to match Rails method and default pound sign

### DIFF
--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -53,7 +53,6 @@ class StimulusReflex::Reflex
   delegate :broadcast, :broadcast_message, to: :broadcaster
   delegate :reflex_id, :reflex_controller, :xpath, :c_xpath, :permanent_attribute_name, to: :client_attributes
   delegate :render, to: :controller_class
-  delegate :dom_id, to: "ActionView::RecordIdentifier"
 
   def initialize(channel, url: nil, element: nil, selectors: [], method_name: nil, params: {}, client_attributes: {})
     @channel = channel

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -157,7 +157,8 @@ class StimulusReflex::Reflex
     @_params ||= ActionController::Parameters.new(request.parameters)
   end
 
-  def dom_id(record_or_class, prefix = "#")
-    ActionView::RecordIdentifier.dom_id record_or_class, prefix
+  def dom_id(record_or_class, prefix = nil, hash: true)
+    value = ActionView::RecordIdentifier.dom_id(record_or_class, prefix)
+    hash ? "##{value}" : value
   end
 end

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -156,4 +156,8 @@ class StimulusReflex::Reflex
   def params
     @_params ||= ActionController::Parameters.new(request.parameters)
   end
+
+  def dom_id(record_or_class, prefix = "#")
+    ActionView::RecordIdentifier.dom_id record_or_class, prefix
+  end
 end

--- a/test/reflex_test.rb
+++ b/test/reflex_test.rb
@@ -27,6 +27,18 @@ class StimulusReflex::ReflexTest < ActionCable::Channel::TestCase
   end
 
   test "dom_id" do
-    assert @reflex.dom_id(TestModel.new(id: 123)) == "test_model_123"
+    assert @reflex.dom_id(TestModel.new(id: 123)) == "#test_model_123"
+  end
+
+  test "dom_id no hash" do
+    assert @reflex.dom_id(TestModel.new(id: 123), nil, hash: false) == "test_model_123"
+  end
+
+  test "dom_id prefix" do
+    assert @reflex.dom_id(TestModel.new(id: 123), "foo") == "#foo_test_model_123"
+  end
+
+  test "dom_id prefix no hash" do
+    assert @reflex.dom_id(TestModel.new(id: 123), "foo", hash: false) == "foo_test_model_123"
   end
 end


### PR DESCRIPTION
# Enhancement

## Description

Improve `dom_id` for reflexes by matching the Rails method signature and prepending with `#` by default.

## Why should this be added

Convenience and developer happiness.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update