### PR TITLE
Prefix dom_id with hash/pound

### DIFF
--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -53,7 +53,6 @@ class StimulusReflex::Reflex
   delegate :broadcast, :broadcast_message, to: :broadcaster
   delegate :reflex_id, :reflex_controller, :xpath, :c_xpath, :permanent_attribute_name, to: :client_attributes
   delegate :render, to: :controller_class
-  delegate :dom_id, to: "ActionView::RecordIdentifier"
 
   def initialize(channel, url: nil, element: nil, selectors: [], method_name: nil, params: {}, client_attributes: {})
     @channel = channel

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -157,7 +157,8 @@ class StimulusReflex::Reflex
     @_params ||= ActionController::Parameters.new(request.parameters)
   end
 
-  def dom_id(record_or_class, prefix = "#")
-    ActionView::RecordIdentifier.dom_id record_or_class, prefix
+  def dom_id(record_or_class, prefix = nil, hash: true)
+    value = ActionView::RecordIdentifier.dom_id(record_or_class, prefix)
+    hash ? "##{value}" : value
   end
 end

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -156,4 +156,8 @@ class StimulusReflex::Reflex
   def params
     @_params ||= ActionController::Parameters.new(request.parameters)
   end
+
+  def dom_id(record_or_class, prefix = "#")
+    ActionView::RecordIdentifier.dom_id record_or_class, prefix
+  end
 end

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -156,8 +156,7 @@ class StimulusReflex::Reflex
     @_params ||= ActionController::Parameters.new(request.parameters)
   end
 
-  def dom_id(record_or_class, prefix = nil, hash: true)
-    value = ActionView::RecordIdentifier.dom_id(record_or_class, prefix)
-    hash ? "##{value}" : value
+  def dom_id(record_or_class, prefix = nil)
+    "#" + ActionView::RecordIdentifier.dom_id(record_or_class, prefix).to_s
   end
 end

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@rails/actioncable": ">= 6.0",
-    "cable_ready": ">= 4.4"
+    "cable_ready": ">= 4.4.6"
   },
   "devDependencies": {
     "@babel/core": "^7.6.2",

--- a/test/reflex_test.rb
+++ b/test/reflex_test.rb
@@ -29,16 +29,4 @@ class StimulusReflex::ReflexTest < ActionCable::Channel::TestCase
   test "dom_id" do
     assert @reflex.dom_id(TestModel.new(id: 123)) == "#test_model_123"
   end
-
-  test "dom_id no hash" do
-    assert @reflex.dom_id(TestModel.new(id: 123), nil, hash: false) == "test_model_123"
-  end
-
-  test "dom_id prefix" do
-    assert @reflex.dom_id(TestModel.new(id: 123), "foo") == "#foo_test_model_123"
-  end
-
-  test "dom_id prefix no hash" do
-    assert @reflex.dom_id(TestModel.new(id: 123), "foo", hash: false) == "foo_test_model_123"
-  end
 end

--- a/test/reflex_test.rb
+++ b/test/reflex_test.rb
@@ -27,6 +27,18 @@ class StimulusReflex::ReflexTest < ActionCable::Channel::TestCase
   end
 
   test "dom_id" do
-    assert @reflex.dom_id(TestModel.new(id: 123)) == "test_model_123"
+    assert @reflex.dom_id(TestModel.new(id: 123)) == "#test_model_123"
+  end
+
+  test "dom_id no hash" do
+    assert @reflex.dom_id(TestModel.new(id: 123), nil, hash: false) == "test_model_123"
+  end
+
+  test "dom_id prefix" do
+    assert @reflex.dom_id(TestModel.new(id: 123), "foo") == "#foo_test_model_123"
+  end
+
+  test "dom_id prefix no hash" do
+    assert @reflex.dom_id(TestModel.new(id: 123), "foo", hash: false) == "foo_test_model_123"
   end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -1254,7 +1254,7 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
-"cable_ready@>= 4.4":
+"cable_ready@>= 4.4.6":
   version "4.4.6"
   resolved "https://registry.yarnpkg.com/cable_ready/-/cable_ready-4.4.6.tgz#a46c879ec48b722d78cb1fbe0c1850d2f6b2762a"
   integrity sha512-nqo50yrnOlV0CKc+ysXnIzwulk7q54hGYUwbJb1s0pBY0eu1yjDhgdU8g9dxfO5xapK6S7oceuEnZ4FQawbU5g==


### PR DESCRIPTION
# Bug Fix

## Description

Prefix `dom_id` with hash/pound.

Fixes dom_id

## Why should this be added

Match CableReady behavior

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update