### PR TITLE
fix 'operartion' typo

### DIFF
--- a/javascript/lifecycle.js
+++ b/javascript/lifecycle.js
@@ -149,7 +149,7 @@ export const dispatchLifecycleEvent = (stage, element, reflexId) => {
 
     if (Debug.enabled)
       console.warn(
-        `StimulusReflex detected that the element which triggered the Reflex has been replaced by a morph operartion. If you rely on all life-cycle methods to be executed, move the Reflex action to an element higher in your DOM.`
+        `StimulusReflex detected that the element which triggered the Reflex has been replaced by a morph operation. If you rely on all life-cycle methods to be executed, move the Reflex action to an element higher in your DOM.`
       )
   }
 


### PR DESCRIPTION
# Type of PR 
Typo

## Description

Fix the  "operartion" typo in the" replaced by a morph operation" warning message.

## Why should this be added

Spelling.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update