### PR TITLE
Fix issue where element may no longer contain reflexData

### DIFF
--- a/javascript/attributes.js
+++ b/javascript/attributes.js
@@ -102,6 +102,9 @@ export const extractDataAttributes = element => {
   return attrs
 }
 
+// A reference to the Stimulus application registered with: StimulusReflex.initialize
+export let stimulusApplication
+
 // Finds an element based on the passed represention of the DOM element's attributes.
 //
 // NOTE: This is the same set of attributes extrated via extractElementAttributes and forwarded to the server side reflex.

--- a/javascript/lifecycle.js
+++ b/javascript/lifecycle.js
@@ -1,5 +1,9 @@
 import { camelize } from './utils'
-import { findElement, extractElementAttributes } from './attributes'
+import {
+  findElement,
+  extractElementAttributes,
+  stimulusApplication
+} from './attributes'
 import Debug from './debug'
 
 // Invokes a lifecycle method on a StimulusReflex controller.
@@ -15,7 +19,18 @@ import Debug from './debug'
 // - element - the element that triggered the reflex (not necessarily the Stimulus controller's element)
 //
 const invokeLifecycleMethod = (stage, element, reflexId) => {
-  if (!element || !element.reflexData[reflexId]) return
+  if (!element || !reflexes[reflexId]) return
+
+  if (Object.entries(element.reflexData).length === 0) {
+    element.reflexData[reflexId] = reflexes[reflexId].promise.data
+    let controllerName = reflexes[reflexId].promise.data.reflexController
+    element.reflexController[
+      reflexId
+    ] = stimulusApplication.getControllerForElementAndIdentifier(
+      element,
+      controllerName
+    )
+  }
 
   const controller = element.reflexController[reflexId]
   const reflex = element.reflexData[reflexId].target

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -12,15 +12,14 @@ import {
   attributeValues,
   extractElementAttributes,
   extractElementDataset,
-  findElement
+  findElement,
+  // A reference to the Stimulus application registered with: StimulusReflex.initialize
+  stimulusApplication
 } from './attributes'
 import { extractReflexName, elementToXPath, xPathToElement } from './utils'
 
 // A lambda that does nothing. Very zen; we are made of stars
 const NOOP = () => {}
-
-// A reference to the Stimulus application registered with: StimulusReflex.initialize
-let stimulusApplication
 
 // A reference to the ActionCable consumer registered with: StimulusReflex.initialize or getConsumer
 let actionCableConsumer


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)
Bug fix
@marcoroth Since you touched these lines last I think it would be appropriate if you could review this. 

## Description
Fixes #413 

In the lifecycle method element.reflexData sometimes only contain an empty object. Since that data is already available elsewhere in `reflexes` we can use the data from there to circumvent the issue. 

This means that when a controller is defined in html as `data-controller="mycontroller"` lifecycle methods will work even for my edge case where it doesn't work. 

## Why should this be added
This seems like a more reliable way of getting the reflex data. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update

Please note that the best way to suggest changes or updates to the [documentation](https://docs.stimulusreflex.com) is to [join Discord](https://discord.gg/XveN625) and leave a note in the #docs channel. Any documentation updates posted as PRs cannot be accepted at this time. :heart:
