### PR TITLE
Bug fix: Updating changelog generator to push to master, not main

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,6 +1,9 @@
 name: Changelog
 
 on:
+  workflow_dispatch:
+  release:
+    types: [created]
   push:
     branches:
       - master
@@ -12,26 +15,27 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[nodoc]')"
     steps:
     - uses: actions/checkout@master
-    - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+    - name: Set up Ruby 3.0
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
-    - uses: actions/cache@v1.1.2
+        ruby-version: 3.0
+    - uses: actions/cache@v2
       with:
         path: vendor/bundle
-        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+        key: ${{ runner.os }}-changelog-gem-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: |
-          ${{ runner.os }}-gem-
+          ${{ runner.os }}-changelog-gem-
     - name: Create local changes
       run: |
         gem install github_changelog_generator
-        github_changelog_generator -u hopsoft -p stimulus_reflex --token ${{ secrets.GITHUB_TOKEN }} --exclude-labels duplicate,question,invalid,wontfix,nodoc
+        github_changelog_generator -u ${{ github.repository_owner }} -p ${{ github.event.repository.name }} --token ${{ secrets.GITHUB_TOKEN }} --exclude-labels duplicate,question,invalid,wontfix,nodoc
     - name: Commit files
       run: |
         git config --local user.email "github-actions@example.com"
         git config --local user.name "GitHub Actions"
-        git commit -m "[nodoc] update changelog" -a
+        git commit -am "[nodoc] Update Changelog" || echo "No changes to commit"
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: ${{ github.ref }}


### PR DESCRIPTION
## Description

The default branch pushed to in `ad-m/github-push-action` was changed to be `main` instead of `master` ( https://github.com/ad-m/github-push-action/pull/69 ), this means the changelog would be pushed to `main`. 

I updated the changelog generator to match what I used on my repo ( https://github.com/bt-rb/bridgetown-minify-html/blob/master/.github/workflows/changelog.yml ) which originally I copied from here.

The new version explicitly pushes to the branch the GitHub action is running on & adds a few "nice to haves" for anyone who wants to copy this Action.

## Why should this be added

While I totally think using `main` as the default branch is cool, I imagine you don't want to get caught out next time you merge a fix.

## Checklist

- [X] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [X] This is not a documentation update