### PR TITLE
controller element holds Reflex metadata

### DIFF
--- a/app/channels/stimulus_reflex/channel.rb
+++ b/app/channels/stimulus_reflex/channel.rb
@@ -41,7 +41,6 @@ class StimulusReflex::Channel < StimulusReflex.configuration.parent_channel.cons
           client_attributes: {
             reflex_id: data["reflexId"],
             xpath: data["xpath"],
-            c_xpath: data["cXpath"],
             reflex_controller: data["reflexController"],
             permanent_attribute_name: permanent_attribute_name
           })

--- a/javascript/log.js
+++ b/javascript/log.js
@@ -1,10 +1,18 @@
-function request (reflexId, target, args, controller, element) {
+function request (
+  reflexId,
+  target,
+  args,
+  controller,
+  element,
+  controllerElement
+) {
   reflexes[reflexId].timestamp = new Date()
   console.log(`\u2191 stimulus \u2191 ${target}`, {
     reflexId,
     args,
     controller,
-    element
+    element,
+    controllerElement
   })
 }
 

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-ClientAttributes = Struct.new(:reflex_id, :reflex_controller, :xpath, :c_xpath, :permanent_attribute_name, keyword_init: true)
+ClientAttributes = Struct.new(:reflex_id, :reflex_controller, :xpath, :permanent_attribute_name, keyword_init: true)
 
 class StimulusReflex::Reflex
   include ActiveSupport::Rescuable
@@ -51,7 +51,7 @@ class StimulusReflex::Reflex
   delegate :connection, :stream_name, to: :channel
   delegate :controller_class, :flash, :session, to: :request
   delegate :broadcast, :broadcast_message, to: :broadcaster
-  delegate :reflex_id, :reflex_controller, :xpath, :c_xpath, :permanent_attribute_name, to: :client_attributes
+  delegate :reflex_id, :reflex_controller, :xpath, :permanent_attribute_name, to: :client_attributes
   delegate :render, to: :controller_class
   delegate :dom_id, to: "ActionView::RecordIdentifier"
 


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Enhancement

## Description

This PR proposes to shift the element which holds Reflex metadata from the element which initiated the Reflex to the element which holds the Reflex controller. While it's frequently true that the element which initiated the Reflex is also holding the controller, it's also quite common for people to pass an element to `stimulate` or put a Stimulus controller on an ancestor of the initiating element so that the developer can make use of SR method callbacks.

## Why should this be added

We frequently see people morphing initiating elements out of the DOM, but still seeing tons of scary warnings about missing elements and failed life-cycle stages. While we can't prevent someone from blowing away their whole DOM, this should fix 90% of the complaints people have about those warnings (and fix callbacks for those Reflexes).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update
