### PR TITLE
Update to work with mutatable CR config

### DIFF
--- a/lib/stimulus_reflex/cable_ready_channels.rb
+++ b/lib/stimulus_reflex/cable_ready_channels.rb
@@ -18,6 +18,7 @@ module StimulusReflex
 
     def method_missing(name, *args)
       return stimulus_reflex_channel.public_send(name, *args) if stimulus_reflex_channel.respond_to?(name)
+      super
     end
 
     def respond_to_missing?(name, include_all)

--- a/lib/stimulus_reflex/cable_ready_channels.rb
+++ b/lib/stimulus_reflex/cable_ready_channels.rb
@@ -2,8 +2,6 @@
 
 module StimulusReflex
   class CableReadyChannels
-    stimulus_reflex_channel_methods = CableReady::Channels.instance.operations.keys + [:broadcast, :broadcast_to]
-    delegate(*stimulus_reflex_channel_methods, to: "stimulus_reflex_channel")
     delegate :[], to: "cable_ready_channels"
 
     def initialize(stream_name)
@@ -16,6 +14,14 @@ module StimulusReflex
 
     def stimulus_reflex_channel
       CableReady::Channels.instance[@stream_name]
+    end
+
+    def method_missing(name, *args)
+      return stimulus_reflex_channel.public_send(name, *args) if stimulus_reflex_channel.respond_to?(name)
+    end
+
+    def respond_to_missing?(name, include_all)
+      stimulus_reflex_channel.respond_to?(name) || super
     end
   end
 end

--- a/lib/stimulus_reflex/logger.rb
+++ b/lib/stimulus_reflex/logger.rb
@@ -79,7 +79,7 @@ module StimulusReflex
       Time.now.strftime("%Y-%m-%d %H:%M:%S")
     end
 
-    def method_missing method
+    def method_missing(method)
       return send(method.to_sym) if private_instance_methods.include?(method.to_sym)
 
       reflex.connection.identifiers.each do |identifier|
@@ -89,7 +89,7 @@ module StimulusReflex
       "-"
     end
 
-    def respond_to_missing? method
+    def respond_to_missing?(method)
       return true if private_instance_methods.include?(method.to_sym)
 
       reflex.connection.identifiers.each do |identifier|

--- a/lib/stimulus_reflex/logger.rb
+++ b/lib/stimulus_reflex/logger.rb
@@ -79,22 +79,22 @@ module StimulusReflex
       Time.now.strftime("%Y-%m-%d %H:%M:%S")
     end
 
-    def method_missing(method)
-      return send(method.to_sym) if private_instance_methods.include?(method.to_sym)
+    def method_missing(name, *args)
+      return send(name) if private_instance_methods.include?(name.to_sym)
 
       reflex.connection.identifiers.each do |identifier|
         ident = reflex.connection.send(identifier)
-        return ident.send(method) if ident.respond_to?(:attributes) && ident.attributes.key?(method.to_s)
+        return ident.send(name) if ident.respond_to?(:attributes) && ident.attributes.key?(name.to_s)
       end
       "-"
     end
 
-    def respond_to_missing?(method)
-      return true if private_instance_methods.include?(method.to_sym)
+    def respond_to_missing?(name, include_all)
+      return true if private_instance_methods.include?(name.to_sym)
 
       reflex.connection.identifiers.each do |identifier|
         ident = reflex.connection.send(identifier)
-        return true if ident.respond_to?(:attributes) && ident.attributes.key?(method.to_s)
+        return true if ident.respond_to?(:attributes) && ident.attributes.key?(name.to_s)
       end
       false
     end

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -55,7 +55,7 @@ class StimulusReflex::Reflex
   delegate :render, to: :controller_class
 
   def initialize(channel, url: nil, element: nil, selectors: [], method_name: nil, params: {}, client_attributes: {})
-    if is_a?(CableReady::Broadcaster)
+    if is_a? CableReady::Broadcaster
       message = <<~MSG
         #{self.class.name} includes CableReady::Broadcaster as an ancestor!
         Reflexes already expose StimulusReflex::Reflex#cable_ready. Please remove CableReady::Broadcaster from the ancestor tree.

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -57,8 +57,11 @@ class StimulusReflex::Reflex
   def initialize(channel, url: nil, element: nil, selectors: [], method_name: nil, params: {}, client_attributes: {})
     if is_a? CableReady::Broadcaster
       message = <<~MSG
-        #{self.class.name} includes CableReady::Broadcaster as an ancestor!
-        Reflexes already expose StimulusReflex::Reflex#cable_ready. Please remove CableReady::Broadcaster from the ancestor tree.
+
+        #{self.class.name} includes CableReady::Broadcaster, and you need to remove it.
+        Reflexes have their own CableReady interface. You can just assume that it's present.
+        See https://docs.stimulusreflex.com/rtfm/cableready#using-cableready-inside-a-reflex-action for more details.
+
       MSG
       raise TypeError.new(message.strip)
     end

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -55,6 +55,14 @@ class StimulusReflex::Reflex
   delegate :render, to: :controller_class
 
   def initialize(channel, url: nil, element: nil, selectors: [], method_name: nil, params: {}, client_attributes: {})
+    if is_a?(CableReady::Broadcaster)
+      message = <<~MSG
+        #{self.class.name} includes CableReady::Broadcaster as an ancestor!
+        Reflexes already expose StimulusReflex::Reflex#cable_ready. Please remove CableReady::Broadcaster from the ancestor tree.
+      MSG
+      raise TypeError.new(message.strip)
+    end
+
     @channel = channel
     @url = url
     @element = element


### PR DESCRIPTION
# Enhancement

Ensure that StimulusReflex works with custom user-added CableReady operations.

Designed to work with: https://github.com/hopsoft/cable_ready/pull/96

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update