### PR TITLE
Fixes bug where multiple inputs with the same name lost element value

### DIFF
--- a/javascript/attributes.js
+++ b/javascript/attributes.js
@@ -65,11 +65,6 @@ export const extractElementAttributes = element => {
     attrs.value = collectedOptions.join(',')
   } else {
     attrs.value = element.value
-    if (element.tagName.match(/select/i)) {
-      if (element.selectedIndex > -1) {
-        attrs.value = element.options[element.selectedIndex].value
-      }
-    }
   }
   return attrs
 }

--- a/javascript/attributes.js
+++ b/javascript/attributes.js
@@ -1,11 +1,17 @@
 import { defaultSchema } from './schema'
 import Debug from './debug'
 
-const multipleInstances = element =>
-  document.querySelectorAll(
-    `input[type="${element.type}"][name="${element.name}"]`
-  ).length > 1
-
+const multipleInstances = element => {
+  if (['checkbox', 'radio'].includes(element.type)) {
+    return (
+      document.querySelectorAll(
+        `input[type="${element.type}"][name="${element.name}"]`
+      ).length > 1
+    )
+  } else {
+    return false
+  }
+}
 const collectCheckedOptions = element => {
   return Array.from(element.querySelectorAll('option:checked'))
     .concat(

--- a/javascript/attributes.js
+++ b/javascript/attributes.js
@@ -8,9 +8,8 @@ const multipleInstances = element => {
         `input[type="${element.type}"][name="${element.name}"]`
       ).length > 1
     )
-  } else {
-    return false
   }
+  return false
 }
 const collectCheckedOptions = element => {
   return Array.from(element.querySelectorAll('option:checked'))

--- a/javascript/test/attributes.extractElementAttributes.test.js
+++ b/javascript/test/attributes.extractElementAttributes.test.js
@@ -70,6 +70,26 @@ describe('extractElementAttributes', () => {
     assert.deepStrictEqual(actual, expected)
   })
 
+  it('returns expected attributes for textbox when multiple inputs with same name', () => {
+    const dom = new JSDOM(`
+      <input name="repeated" type="text" id="example" value="StimulusReflex" />
+      <input name="repeated" type="text" id="another" value="StimulusReflex" />
+    `)
+    global.document = dom.window.document
+    const element = dom.window.document.querySelector('input#example')
+    const actual = extractElementAttributes(element)
+    const expected = {
+      type: 'text',
+      id: 'example',
+      name: 'repeated',
+      value: 'StimulusReflex',
+      tag_name: 'INPUT',
+      checked: false,
+      selected: false
+    }
+    assert.deepStrictEqual(actual, expected)
+  })
+
   it('returns expected attributes for unchecked checkbox', () => {
     const dom = new JSDOM('<input type="checkbox" id="example" />')
     global.document = dom.window.document


### PR DESCRIPTION

# Bugfix

## Description

- allows only checkbox and radio inputs to be multipleInstances
- adds failing test for multiple text inputs with same name attribute

Fixes https://github.com/hopsoft/stimulus_reflex/issues/425

## Why should this be added

To prevent confusion for future users of the gem particularly in cases where there are multiple nested forms using rails helpers that would generate the same name for inputs on the same page. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update

Please note that the best way to suggest changes or updates to the [documentation](https://docs.stimulusreflex.com) is to [join Discord](https://discord.gg/XveN625) and leave a note in the #docs channel. Any documentation updates posted as PRs cannot be accepted at this time. :heart:
