### PR TITLE
more explicit quick_start doc increment example

### DIFF
--- a/docs/hello-world/quickstart.md
+++ b/docs/hello-world/quickstart.md
@@ -42,7 +42,7 @@ This example updates the page with the latest count when the link is clicked:
   data-reflex="click->Counter#increment"
   data-step="1" 
   data-count="<%= @count.to_i %>"
->Increment <%= @count.to_i %></a>
+>Increment <%= @count.present? ? @count.to_i : "from 0" %></a>
 ```
 {% endcode %}
 


### PR DESCRIPTION
Hi and thank you for a super nice approach. 

I'm just learning discovering Stimulus Reflex, and while going through the quick start example, I found it slightly complicated to understand. I had a hard time understanding how instance variables set inside Reflexes would become available in the view, and how it interacted with controller set instance variables.

I think part of this blur came from the fact that your example currently relies on the fact that `nil.to_i == 0` which is not super obvious or expected. I'm suggesting a slightly more explicit code that explicitly tests for the presence of the instance variable in the view and then does something. I hope it may help future readers to understand that the variable will only be set when coming from a reflex, and not from a regular page load.  

I had to watch the nice and short screencast to actually understand this. Maybe it'd be nice to actually a small piece of doc about this interaction with instance variable set in controllers, but I'll leave that up to you!

# Type of PR (feature, enhancement, bug fix, etc.)

## Description

Please include a summary of the change and which issue is fixed.

Fixes # (issue)

## Why should this be added

Explain value.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] Checks (StandardRB & Prettier-Standard) are passing
- [ ] This is not a documentation update

Please note that the best way to suggest changes or updates to the [documentation](https://docs.stimulusreflex.com) is to [join Discord](https://discord.gg/XveN625) and leave a note in the #docs channel. Any documentation updates posted as PRs cannot be accepted at this time. :heart:
