### PR TITLE
refactor declarative reflex observer

### DIFF
--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -489,20 +489,20 @@ const initialize = (application, initializeOptions = {}) => {
     controller || StimulusReflexController
   )
   Debug.set(!!debug)
+  const observer = new MutationObserver(setupDeclarativeReflexes)
+  observer.observe(document.documentElement, {
+    attributeFilter: [
+      stimulusApplication.schema.reflexAttribute,
+      stimulusApplication.schema.controllerAttribute,
+      stimulusApplication.schema.actionAttribute
+    ],
+    childList: true,
+    subtree: true
+  })
 }
 
 if (!document.stimulusReflexInitialized) {
   document.stimulusReflexInitialized = true
-
-  window.addEventListener('load', () => {
-    setupDeclarativeReflexes()
-    const observer = new MutationObserver(setupDeclarativeReflexes)
-    observer.observe(document.documentElement, {
-      attributes: true,
-      childList: true,
-      subtree: true
-    })
-  })
 
   const beforeDOMUpdate = event => {
     const { stimulusReflex } = event.detail || {}
@@ -602,6 +602,8 @@ if (!document.stimulusReflexInitialized) {
       )
   })
 }
+
+window.addEventListener('load', setupDeclarativeReflexes)
 
 export default {
   initialize,

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -491,11 +491,7 @@ const initialize = (application, initializeOptions = {}) => {
   Debug.set(!!debug)
   const observer = new MutationObserver(setupDeclarativeReflexes)
   observer.observe(document.documentElement, {
-    attributeFilter: [
-      stimulusApplication.schema.reflexAttribute,
-      stimulusApplication.schema.controllerAttribute,
-      stimulusApplication.schema.actionAttribute
-    ],
+    attributeFilter: [stimulusApplication.schema.reflexAttribute],
     childList: true,
     subtree: true
   })


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bug fix

## Description

SR uses a MutationObserver to watch the DOM for any changes. This is unnecessary because we're just looking for updates to the `data-reflex` and `data-controller` attributes. Observing all attributes uses more resources and has un-cool side-effects for libraries that rapidly change attributes such as GSAP animation.

By moving the observer setup to the SR initialize (which only gets run once) we gain access to the Stimulus application schema, which can be used to provide an array of attributes to monitor.

**Question**: do we need to monitor `data-action`? For that matter, do we need to monitor `data-controller`? I think there's a good chance we *only* care about `data-reflex`.

**Question**: did you choose to use the `window` `load` event over `DOMContentLoaded` for a specific reason? I don't know if it's right or wrong, just curious for insight.

Fixes leastbad/radiolabel#3

## Why should this be added

radiolabel users are seeing their DOM scanned over 200 times every time there's a Reflex operation. Even `setupDeclarativeReflexes` will cause `setupDeclarativeReflexes` to be fired. This is over-zealous.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update
