### PR TITLE
Update README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -39,7 +39,7 @@ Find out more and learn how to upgrade on the [Release History](appendices/relea
 
 Our over-the-wire JavaScript payload size is a tiny [**11.4kb** gzipped](https://bundlephobia.com/result?p=stimulus_reflex@3.4.0)... and that _includes_ StimulusReflex, ActionCable, morphdom and CableReady.
 
-While StimulusReflex is a radically different approach that makes it hard to do a direct comparison to the popular SPA frameworks, the one thing everyone seems to agree on is how small their Todo List implementation is. Here's the numbers:
+While StimulusReflex is a radically different approach that makes it hard to do a direct comparison to the popular SPA frameworks, the one thing everyone seems to agree on is how small their Todo List implementation is. Here're the numbers:
 
 | Tool | Wire Size |
 | :--- | :--- |


### PR DESCRIPTION
Fix grammar here's -> here're

# Docs fix

## Description

Very minor grammar fix. 

## Why should this be added

Just trying to contribute!

## Checklist

Please note that the best way to suggest changes or updates to the [documentation](https://docs.stimulusreflex.com) is to [join Discord](https://discord.gg/XveN625) and leave a note in the #docs channel. Any documentation updates posted as PRs cannot be accepted at this time. :heart:

Hmmm, after reading this, I see this is not the way to go, but I'm not going to join the discord channel, so maybe you can axe this but still incorporate it through some other means.
