### PR TITLE
delegate broadcast to cable_ready_channels

### DIFF
--- a/lib/stimulus_reflex/cable_ready_channels.rb
+++ b/lib/stimulus_reflex/cable_ready_channels.rb
@@ -2,7 +2,7 @@
 
 module StimulusReflex
   class CableReadyChannels
-    delegate :[], to: "cable_ready_channels"
+    delegate :[], :broadcast, to: "cable_ready_channels"
 
     def initialize(stream_name)
       @stream_name = stream_name


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bug fix

## Description

@josefrichter discovered a bug in the CableReadyChannels proxy:

```rb
cable_ready["timeline"].inner_html(...)
cable_ready.broadcast # nothing happens
```

I realized that we need to delegate `broadcast` along with `[]`. @hopsoft will this have unintended side-effects?

## Why should this be added

Devs should be able to call `cable_ready.broadcast` in a Reflex and expect it to work consistently.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update