### PR TITLE
Extract method invocation policy

### DIFF
--- a/app/channels/stimulus_reflex/channel.rb
+++ b/app/channels/stimulus_reflex/channel.rb
@@ -115,11 +115,11 @@ class StimulusReflex::Channel < StimulusReflex.configuration.parent_channel.cons
 
   def delegate_call_to_reflex(reflex, method_name, arguments = [])
     method = reflex.method(method_name)
-    policy = ReflexMethodInvocationPolicy.new(method, arguments)
+    policy = StimulusReflex::ReflexMethodInvocationPolicy.new(method, arguments)
 
-    if policy.arguments_empty_allowed?
+    if policy.no_arguments?
       reflex.process(method_name)
-    elsif policy.arguments_size_allowed?
+    elsif policy.arguments?
       reflex.process(method_name, *arguments)
     else
       raise ArgumentError.new("wrong number of arguments (given #{arguments.inspect}, expected #{required_params.inspect}, optional #{optional_params.inspect})")
@@ -141,24 +141,6 @@ class StimulusReflex::Channel < StimulusReflex.configuration.parent_channel.cons
   def fix_environment!
     ([ApplicationController] + ApplicationController.descendants).each do |controller|
       controller.renderer.instance_variable_set(:@env, connection.env.merge(controller.renderer.instance_variable_get(:@env)))
-    end
-  end
-
-  class ReflexMethodInvocationPolicy
-    attr_reader :arguments, :required_params, :optional_params
-
-    def initialize(method, arguments)
-      @arguments = arguments
-      @required_params = method.parameters.select { |(kind, _)| kind == :req }
-      @optional_params = method.parameters.select { |(kind, _)| kind == :opt }
-    end
-
-    def arguments_empty_allowed?
-      arguments.size == 0 && required_params.size == 0
-    end
-
-    def arguments_size_allowed?
-      arguments.size >= required_params.size && arguments.size <= required_params.size + optional_params.size
     end
   end
 end

--- a/app/channels/stimulus_reflex/channel.rb
+++ b/app/channels/stimulus_reflex/channel.rb
@@ -115,12 +115,11 @@ class StimulusReflex::Channel < StimulusReflex.configuration.parent_channel.cons
 
   def delegate_call_to_reflex(reflex, method_name, arguments = [])
     method = reflex.method(method_name)
-    required_params = method.parameters.select { |(kind, _)| kind == :req }
-    optional_params = method.parameters.select { |(kind, _)| kind == :opt }
+    policy = ReflexMethodInvocationPolicy.new(method, arguments)
 
-    if arguments.size == 0 && required_params.size == 0
+    if policy.arguments_empty_allowed?
       reflex.process(method_name)
-    elsif arguments.size >= required_params.size && arguments.size <= required_params.size + optional_params.size
+    elsif policy.arguments_size_allowed?
       reflex.process(method_name, *arguments)
     else
       raise ArgumentError.new("wrong number of arguments (given #{arguments.inspect}, expected #{required_params.inspect}, optional #{optional_params.inspect})")
@@ -142,6 +141,24 @@ class StimulusReflex::Channel < StimulusReflex.configuration.parent_channel.cons
   def fix_environment!
     ([ApplicationController] + ApplicationController.descendants).each do |controller|
       controller.renderer.instance_variable_set(:@env, connection.env.merge(controller.renderer.instance_variable_get(:@env)))
+    end
+  end
+
+  class ReflexMethodInvocationPolicy
+    attr_reader :arguments, :required_params, :optional_params
+
+    def initialize(method, arguments)
+      @arguments = arguments
+      @required_params = method.parameters.select { |(kind, _)| kind == :req }
+      @optional_params = method.parameters.select { |(kind, _)| kind == :opt }
+    end
+
+    def arguments_empty_allowed?
+      arguments.size == 0 && required_params.size == 0
+    end
+
+    def arguments_size_allowed?
+      arguments.size >= required_params.size && arguments.size <= required_params.size + optional_params.size
     end
   end
 end

--- a/lib/stimulus_reflex.rb
+++ b/lib/stimulus_reflex.rb
@@ -20,6 +20,7 @@ require "stimulus_reflex/broadcasters/broadcaster"
 require "stimulus_reflex/broadcasters/nothing_broadcaster"
 require "stimulus_reflex/broadcasters/page_broadcaster"
 require "stimulus_reflex/broadcasters/selector_broadcaster"
+require "stimulus_reflex/policies/reflex_invocation_policy"
 require "stimulus_reflex/utils/colorize"
 require "stimulus_reflex/logger"
 

--- a/lib/stimulus_reflex/policies/reflex_invocation_policy.rb
+++ b/lib/stimulus_reflex/policies/reflex_invocation_policy.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module StimulusReflex
+  class ReflexMethodInvocationPolicy
+    attr_reader :arguments, :required_params, :optional_params
+
+    def initialize(method, arguments)
+      @arguments = arguments
+      @required_params = method.parameters.select { |(kind, _)| kind == :req }
+      @optional_params = method.parameters.select { |(kind, _)| kind == :opt }
+    end
+
+    def no_arguments?
+      arguments.size == 0 && required_params.size == 0
+    end
+
+    def arguments?
+      arguments.size >= required_params.size && arguments.size <= required_params.size + optional_params.size
+    end
+
+    def unknown?
+      # noop
+    end
+  end
+end

--- a/lib/stimulus_reflex/policies/reflex_invocation_policy.rb
+++ b/lib/stimulus_reflex/policies/reflex_invocation_policy.rb
@@ -19,7 +19,10 @@ module StimulusReflex
     end
 
     def unknown?
-      # noop
+      return false if no_arguments?
+      return false if arguments?
+
+      true
     end
   end
 end

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -106,6 +106,7 @@ class StimulusReflex::Reflex
     end
   end
 
+  # Invoke the reflex action specified by `name` and run all callbacks
   def process(name, *args)
     reflex_invoked = false
     result = run_callbacks(:process) {


### PR DESCRIPTION
# Refactor

## Description

Extract a `ReflexMethodInvocationPolicy` class that clarifies when a reflex method is allowed to be called

## Why should this be added

I did this as part of @r00k's code quality challenge - today's challenge was to extract a compound conditional. If nothing else, it clarifies things up a bit and made me grok what this part of the code does a bit better. Tiny wins!

## Checklist

- [X] My code follows the style guidelines of this project
- [X] Checks (StandardRB & Prettier-Standard) are passing
- [X] This is not a documentation update

Please note that the best way to suggest changes or updates to the [documentation](https://docs.stimulusreflex.com) is to [join Discord](https://discord.gg/XveN625) and leave a note in the #docs channel. Any documentation updates posted as PRs cannot be accepted at this time. :heart:
