### PR TITLE
run changelog action not on every single push to master

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -32,8 +32,8 @@ jobs:
         github_changelog_generator -u ${{ github.repository_owner }} -p ${{ github.event.repository.name }} --token ${{ secrets.GITHUB_TOKEN }} --exclude-labels duplicate,question,invalid,wontfix,nodoc
     - name: Commit files
       run: |
-        git config --local user.email "github-actions@example.com"
-        git config --local user.name "GitHub Actions"
+        git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config --local user.name "github-actions[bot]"
         git commit -am "[nodoc] Update Changelog" || echo "No changes to commit"
     - name: Push changes
       uses: ad-m/github-push-action@master

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -3,15 +3,16 @@ name: Changelog
 on:
   workflow_dispatch:
   release:
-    types: [created]
-  push:
-    branches:
-      - master
+  pull_request:
+    types: [opened, closed, reopened, labeled, unlabeled]
+  issues:
+    types: [opened, closed, reopened, labeled, unlabeled, deleted]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 4
+    if: github.ref == 'refs/heads/master'
     if: "!contains(github.event.head_commit.message, '[nodoc]')"
     steps:
     - uses: actions/checkout@master


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Enhancement

## Description

Run changelog action not on every single push to master

## Why should this be added

Less changelog commits noise.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update