### PR TITLE
handle generated value for channel_prefix if app directory contains dots or spaces

### DIFF
--- a/lib/tasks/stimulus_reflex/install.rake
+++ b/lib/tasks/stimulus_reflex/install.rake
@@ -61,7 +61,7 @@ namespace :stimulus_reflex do
       lines.delete_at 1
       lines.insert 1, "  adapter: redis\n"
       lines.insert 2, "  url: <%= ENV.fetch(\"REDIS_URL\") { \"redis://localhost:6379/1\" } %>\n"
-      lines.insert 3, "  channel_prefix: " + File.basename(Rails.root.to_s).underscore + "_development\n"
+      lines.insert 3, "  channel_prefix: " + File.basename(Rails.root.to_s).tr('\\', "").tr("-. ", "_").underscore + "_development\n"
       File.open(filepath, "w") { |f| f.write lines.join }
     end
 


### PR DESCRIPTION
Hello dear Stimulus Reflex folks :wave:

# Type of PR

Bug fix

## Description

In a project, I noticed that after running `stimulus_reflex:install` the generated `config/cable.yml` looked weird:

```yml
development:
  adapter: redis
  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
  channel_prefix: foo bar_development # note the space " " between foo and bar
```

`install.rake` uses the app's root directory name to generate the value for `channel_prefix`, but it doesn't handle dots "." and/or spaces " ".

This PR follows the same strategy as Rails' `app_name` (https://github.com/rails/rails/blob/7f02924fe65446a7cbbc29d91cf96d457b94c2de/railties/lib/rails/generators/app_name.rb#L10) to fix this.

---

I also saw that there was a [previous implementation](https://github.com/hopsoft/stimulus_reflex/commit/91d3d1e72b53d63ab4dd9ef3b77c6d5cd1a0e830#diff-6e9b7d2357420583f87e107db88596b41a43293be8003312ed27339331763c35) to generate that value. This was used:

```ruby
Rails.application.class.module_parent.to_s.underscore
```

but that caused an error in Rails 5.2 because `module_parent` is a method that was renamed from `parent` (see https://github.com/rails/rails/pull/34051) after 5.2.

Alternatively we could go back to this approach and handle the case where `module_parent` is `undefined`, something like this

```ruby
app_klass = Rails.application.class
app_module_parent = app_klass.respond_to(:module_parent) ? app_klass.module_parent : app_klass.parent
app_name = app_module_parent.to_s.underscore
```

I don't know... other ideas?

## Why should this be added

I believe it solves a bug.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update

Please note that the best way to suggest changes or updates to the [documentation](https://docs.stimulusreflex.com) is to [join Discord](https://discord.gg/stimulus-reflex) and leave a note in the #docs channel. Any documentation updates posted as PRs cannot be accepted at this time. :heart:
