### PR TITLE
add support for prepend and append reflex callbacks

### DIFF
--- a/lib/stimulus_reflex/callbacks.rb
+++ b/lib/stimulus_reflex/callbacks.rb
@@ -22,6 +22,18 @@ module StimulusReflex
         add_callback(:around, *args, &block)
       end
 
+      def prepend_before_reflex(*args, &block)
+        prepend_callback(:before, *args, &block)
+      end
+
+      def prepend_after_reflex(*args, &block)
+        prepend_callback(:after, *args, &block)
+      end
+
+      def prepend_around_reflex(*args, &block)
+        prepend_callback(:around, *args, &block)
+      end
+
       def skip_before_reflex(*args, &block)
         omit_callback(:before, *args, &block)
       end
@@ -34,23 +46,44 @@ module StimulusReflex
         omit_callback(:around, *args, &block)
       end
 
+      alias_method :append_before_reflex, :before_reflex
+      alias_method :append_around_reflex, :around_reflex
+      alias_method :append_after_reflex, :after_reflex
+
       private
 
       def add_callback(kind, *args, &block)
-        set_callback(*[:process, kind, args, normalize_callback_options!(args)].flatten, &block)
+        insert_callbacks(args, block) do |name, options|
+          set_callback(:process, kind, name, options)
+        end
+      end
+
+      def prepend_callback(kind, *args, &block)
+        insert_callbacks(args, block) do |name, options|
+          set_callback(:process, kind, name, options.merge(prepend: true))
+        end
       end
 
       def omit_callback(kind, *args, &block)
-        skip_callback(*[:process, kind, args, normalize_callback_options!(args)].flatten, &block)
+        insert_callbacks(args) do |name, options|
+          skip_callback(:process, kind, name, options)
+        end
       end
 
-      def normalize_callback_options!(args)
-        options = args.extract_options!
-        options.assert_valid_keys :if, :unless, :only, :except
+      def insert_callbacks(callbacks, block = nil)
+        options = callbacks.extract_options!
+        normalize_callback_options!(options)
 
+        callbacks.push(block) if block
+
+        callbacks.each do |callback|
+          yield callback, options
+        end
+      end
+
+      def normalize_callback_options!(options)
         normalize_callback_option! options, :only, :if
         normalize_callback_option! options, :except, :unless
-        options
       end
 
       def normalize_callback_option!(options, from, to)


### PR DESCRIPTION
# Type of PR

Enhancement

## Description

This PR adds methods to prepend or append reflex callbacks. The following methods are introduced:

* `prepend_before_reflex`
* `prepend_around_reflex`
* `prepend_after_reflex`
* `append_before_reflex`
* `append_around_reflex`
* `append_after_reflex`

## Why should this be added

This can be useful if you inherit from a reflex but want to prepend/append previously defined callbacks. This implementation aims to be as close as possible to [`AbstractController::Callbacks`](https://api.rubyonrails.org/classes/AbstractController/Callbacks.html).

This PR completes to callbacks functionality as previously introduced in #160 and #466.

### Example:

```ruby
class ApplicationReflex < StimulusReflex::Reflex
  before_reflex :track_event

  # ...

  private

  def track_event
    # ...
  end
end

class CounterReflex < ApplicationReflex
  prepend_before_reflex :something_before_track_event

  def increment
    # ...
  end
  
  private

  def something_before_track_event
    # this will be executed before `ApplicationReflex#track_event`
  end
end
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update

Please note that the best way to suggest changes or updates to the [documentation](https://docs.stimulusreflex.com) is to [join Discord](https://discord.gg/stimulus-reflex) and leave a note in the #docs channel. Any documentation updates posted as PRs cannot be accepted at this time. :heart:
