### PR TITLE
fix changelog workflow and optimize triggers

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -3,19 +3,21 @@ name: Changelog
 on:
   workflow_dispatch:
   release:
+    types: [released, prereleased, deleted]
   pull_request:
-    types: [opened, closed, reopened, labeled, unlabeled]
+    types: [closed]
   issues:
-    types: [opened, closed, reopened, labeled, unlabeled, deleted]
+    types: [closed, deleted]
 
 jobs:
-  build:
+  changelog:
     runs-on: ubuntu-latest
     timeout-minutes: 4
-    if: github.ref == 'refs/heads/master'
-    if: "!contains(github.event.head_commit.message, '[nodoc]')"
+    if: "!contains(github.event.head_commit.message, 'Update Changelog')"
     steps:
     - uses: actions/checkout@master
+      with:
+        ref: master
     - name: Set up Ruby 3.0
       uses: ruby/setup-ruby@v1
       with:
@@ -34,9 +36,9 @@ jobs:
       run: |
         git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git config --local user.name "github-actions[bot]"
-        git commit -am "[nodoc] Update Changelog" || echo "No changes to commit"
+        git commit -am "Update Changelog" || echo "No changes to commit"
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        branch: ${{ github.ref }}
+        branch: master


### PR DESCRIPTION
# Type of PR 

Bug Fix

## Description

Looks like I broke the changelog generator in #450. The last few [runs](https://github.com/hopsoft/stimulus_reflex/actions/workflows/changelog.yml) all failed 🙈

This PR fixes that and optimizes the triggers so it doesn't kick off a bunch of useless action runs.

## Why should this be added

* Up to date changelog
* The commit history is less noisy

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update
