### PR TITLE
add `useReflex` js function to "support" the composable pattern

### DIFF
--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -224,6 +224,10 @@ const register = (controller, options = {}) => {
   })
 }
 
+const useReflex = (controller, options = {}) => {
+  register(controller, options)
+}
+
 document.addEventListener('stimulus-reflex:server-message', serverMessage)
 document.addEventListener('cable-ready:before-inner-html', beforeDOMUpdate)
 document.addEventListener('cable-ready:before-morph', beforeDOMUpdate)
@@ -234,6 +238,7 @@ window.addEventListener('load', setupDeclarativeReflexes)
 export default {
   initialize,
   register,
+  useReflex,
   get debug () {
     return Debug.value
   },


### PR DESCRIPTION
# Type of PR 

"Feature"

## Description

This PR adds the`useReflex()` js function to "support" the composable pattern.

## Why should this be added

This can be useful if you include a handful of mixins in your `connect()` function (e.g. some mixins from `stimulus-use`) and want them to all look similar. `StimulusReflex.register(this)` would stick out in that matter.

### Example

```js
import { Controller } from 'stimulus'
import { useReflex } from 'stimulus_reflex'
import { useResize, useIdle } from 'stimulus-use'

export default class extends Controller {
  connect() {
    useReflex(this)
    useResize(this)
    useIdle(this)
    // ...
  }

  // ...
}
```

Reference:
* https://github.com/stimulus-use/stimulus-use
* https://www.betterstimulus.com/architecture/mixins.html


## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update