### PR TITLE
Mutation observer wouldn't fire in certain situations

### DIFF
--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -54,7 +54,10 @@ const initialize = (application, initializeOptions = {}) => {
   Debug.set(!!debug)
   const observer = new MutationObserver(setupDeclarativeReflexes)
   observer.observe(document.documentElement, {
-    attributeFilter: [reflexes.app.schema.reflexAttribute, reflexes.app.schema.actionAttribute],
+    attributeFilter: [
+      reflexes.app.schema.reflexAttribute,
+      reflexes.app.schema.actionAttribute
+    ],
     childList: true,
     subtree: true
   })

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -54,7 +54,7 @@ const initialize = (application, initializeOptions = {}) => {
   Debug.set(!!debug)
   const observer = new MutationObserver(setupDeclarativeReflexes)
   observer.observe(document.documentElement, {
-    attributeFilter: [reflexes.app.schema.reflexAttribute],
+    attributes: true,
     childList: true,
     subtree: true
   })

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -54,7 +54,7 @@ const initialize = (application, initializeOptions = {}) => {
   Debug.set(!!debug)
   const observer = new MutationObserver(setupDeclarativeReflexes)
   observer.observe(document.documentElement, {
-    attributes: true,
+    attributeFilter: [reflexes.app.schema.reflexAttribute, reflexes.app.schema.actionAttribute],
     childList: true,
     subtree: true
   })


### PR DESCRIPTION
In certain situations where you're morphing an element that does not contain a data-reflex attribute, the mutation observer wouldn't fire.

# Type of PR (feature, enhancement, bug fix, etc.)
bug fix

## Description

The attributeFilter option of mutation observer checks that any changed element has any attribute in the list of filters. If you morph an element without a `data-reflex`attribute, this mutation observer won't fire.

![W4KRcTF9nt](https://user-images.githubusercontent.com/1729810/112463186-b3dd9a00-8d40-11eb-9d1b-58a877a2d742.gif)

**@leastbad's note**: adding `actionAttribute` to the list of observed attributes is a viable solution because `setupDeclarativeReflexes` adds `__perform`, a private/internal action. This makes it a reliable litmus test for the edge case this PR addresses.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update
