### PR TITLE
Reinitialize controller_class renderer with connection.env

### DIFF
--- a/app/channels/stimulus_reflex/channel.rb
+++ b/app/channels/stimulus_reflex/channel.rb
@@ -11,7 +11,6 @@ class StimulusReflex::Channel < StimulusReflex.configuration.parent_channel.cons
 
   def subscribed
     super
-    fix_environment!
     stream_from stream_name
   end
 
@@ -144,11 +143,5 @@ class StimulusReflex::Channel < StimulusReflex.configuration.parent_channel.cons
 
   def exception_message_with_backtrace(exception)
     "#{exception}\n#{exception.backtrace.first}"
-  end
-
-  def fix_environment!
-    ([ApplicationController] + ApplicationController.descendants).each do |controller|
-      controller.renderer.instance_variable_set(:@env, connection.env.merge(controller.renderer.instance_variable_get(:@env)))
-    end
   end
 end

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -16,7 +16,6 @@ class StimulusReflex::Reflex
   delegate :controller_class, :flash, :session, to: :request
   delegate :broadcast, :broadcast_message, to: :broadcaster
   delegate :reflex_id, :reflex_controller, :xpath_controller, :xpath_element, :permanent_attribute_name, to: :client_attributes
-  delegate :render, to: :controller_class
 
   def initialize(channel, url: nil, element: nil, selectors: [], method_name: nil, params: {}, client_attributes: {})
     if is_a? CableReady::Broadcaster
@@ -110,6 +109,10 @@ class StimulusReflex::Reflex
 
   def controller?
     !!defined? @controller
+  end
+
+  def render(*args)
+    controller_class.renderer.new(connection.env).render(*args)
   end
 
   # Invoke the reflex action specified by `name` and run all callbacks


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bug fix

## Description

Assuming people use the `render` method, this initializes the mock controller `renderer` instance with the `connection.env`.

We should update the docs to say that if people use `ArbitraryController.render` then they should *actually* use `ArbitraryController.renderer.new(connection.env).render` instead.

## Why should this be added

Should prevent "session bleed".

# Testing

```rb
# app/helpers/home_helper.rb
module HomeHelper
  def shitblast
    "yummy"
  end
end
```
```erb
<div class="card-body d-flex justify-content-center">
  <div id="test"></div>
  <button class="btn btn-dark" type="button" data-reflex="click->Example#renderer">Test</button>
</div>
```
```erb
<%# app/views/home/_test.html.erb %>
<%= current_user.name %><br>
<%= shitblast %><br>
<%= home_path %><br>
<%= render partial: "home/test2" %>
```
```erb
<%# app/views/home/_test2.html.erb %>
Yowza!
<%= current_user.name %><br>
<%= shitblast %><br>
<%= home_path %><br>
```
```rb
class ExampleReflex < ApplicationReflex
  def renderer
    morph "#test", render(partial: "home/test")
  end
end
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update