### PR TITLE
Fix Changelog Action

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -15,28 +15,30 @@ jobs:
     timeout-minutes: 4
     if: "!contains(github.event.head_commit.message, 'Update Changelog')"
     steps:
-    - uses: actions/checkout@master
+    
+    - name: Checkout Repository
+      uses: actions/checkout@master
       with:
-        ref: master
+        persist-credentials: false
+        fetch-depth: 0
+        
     - name: Set up Ruby 3.0
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.0
-    - uses: actions/cache@v2
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-changelog-gem-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-changelog-gem-
-    - name: Create local changes
+        bundler-cache: true
+
+    - name: Create Changelog
       run: |
         gem install github_changelog_generator
         github_changelog_generator -u ${{ github.repository_owner }} -p ${{ github.event.repository.name }} --token ${{ secrets.GITHUB_TOKEN }} --exclude-labels duplicate,question,invalid,wontfix,nodoc
+
     - name: Commit files
       run: |
         git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git config --local user.name "github-actions[bot]"
         git commit -am "Update Changelog" || echo "No changes to commit"
+
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:


### PR DESCRIPTION
# Type of PR

Bug Fix

## Description

As noted in the [README of `ad-m/github-push-action`](https://github.com/ad-m/github-push-action#example-workflow-file) it seems that the `actions/checkout` action needs the following params:

```yml
    - uses: actions/checkout@v2
      with:
        persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
        fetch-depth: 0 # otherwise, it will fail to push refs to dest repo
```

(It now also uses the built-in bundler cache provided by the `ruby/setup-ruby` action)

## Why should this be added

The Changelog Actions currently doesn't work

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update
