### PR TITLE
prevent /cable from being prepended to ActiveStorage route helpers

### DIFF
--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -110,7 +110,7 @@ class StimulusReflex::Reflex
   end
 
   def render(*args)
-    controller_class.renderer.new(connection.env).render(*args)
+    controller_class.renderer.new(connection.env.merge("SCRIPT_NAME": "")).render(*args)
   end
 
   # Invoke the reflex action specified by `name` and run all callbacks


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bug fix

## Description

I observed that when using our brand new `render` helper to render a partial that contains ActiveStorage route helpers such as `rails_blob_path` and `object.blob.representation`, the ActionCable mount URL would be prepended to the ActiveStorage route path generated, breaking the route.

After substantial experimentation and general frustration, I was able to suppress this behaviour by setting the `SCRIPT_NAME` value to `""`.

I have verified that this solution provides a successful outcome in the following scenarios:

- rendering partials within partials
- calling current_user.name
- calling a controller-specific helper
- calling a route helper

My current best guess is that if the change I made is going to cause problems, it'll be when trying to call our `render` helper inside of a Reflex, **inside of an Engine**.

As of the time I'm creating this PR, I've not been able to test the above scenario. If someone is able to quickly spin up an engine to test, I would be highly appreciative.

## Why should this be added

Developers rightly expect all Rails-provided helpers to work normally.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update