### PR TITLE
Fix broken link in docs

### DIFF
--- a/docs/rtfm/reflexes.md
+++ b/docs/rtfm/reflexes.md
@@ -125,7 +125,7 @@ export default class extends ApplicationController {
 
 This is possible because `ApplicationController` imports the StimulusReflex Controller and calls `StimulusReflex.register(this)`. As a result, `ApplicationController` and all Stimulus Controllers  that extend it gain a method called `stimulate`.
 
-When you use declarative Reflex calls via `data-reflex` attributes in your HTML, the `stimulate` method is called for you. 🤯 You will learn all about this process in [Understanding Reflex Controllers](reflexes.md#understanding-reflex-controllers).
+When you use declarative Reflex calls via `data-reflex` attributes in your HTML, the `stimulate` method is called for you. 🤯 You will learn all about this process in [Understanding Reflex Controllers](reflexes.md#understanding-stimulusreflex-controllers).
 
 ### `stimulate` is extremely flexible
 


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bug fix

## Description

Fixed broken anchor link in docs

## Why should this be added

So dead link in docs is fixed. Sorry I broke the rule below, feel free to close if unwanted

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [ ] This is not a documentation update

Please note that the best way to suggest changes or updates to the [documentation](https://docs.stimulusreflex.com) is to [join Discord](https://discord.gg/stimulus-reflex) and leave a note in the #docs channel. Any documentation updates posted as PRs cannot be accepted at this time. :heart:
