### PR TITLE
Introduce StimulusReflex Targets

### DIFF
--- a/app/channels/stimulus_reflex/channel.rb
+++ b/app/channels/stimulus_reflex/channel.rb
@@ -19,6 +19,7 @@ class StimulusReflex::Channel < StimulusReflex.configuration.parent_channel.cons
     selectors = (data["selectors"] || []).select(&:present?)
     selectors = data["selectors"] = ["body"] if selectors.blank?
     target = data["target"].to_s
+    targets = data["targets"] || {}
     reflex_name, method_name = target.split("#")
     reflex_name = reflex_name.camelize
     reflex_name = reflex_name.end_with?("Reflex") ? reflex_name : "#{reflex_name}Reflex"
@@ -36,6 +37,7 @@ class StimulusReflex::Channel < StimulusReflex.configuration.parent_channel.cons
           data: data,
           selectors: selectors,
           method_name: method_name,
+          targets: targets,
           params: params,
           client_attributes: {
             reflex_id: data["reflexId"],

--- a/app/channels/stimulus_reflex/channel.rb
+++ b/app/channels/stimulus_reflex/channel.rb
@@ -23,7 +23,6 @@ class StimulusReflex::Channel < StimulusReflex.configuration.parent_channel.cons
     reflex_name = reflex_name.camelize
     reflex_name = reflex_name.end_with?("Reflex") ? reflex_name : "#{reflex_name}Reflex"
     arguments = (data["args"] || []).map { |arg| object_with_indifferent_access arg }
-    element = StimulusReflex::Element.new(data)
     permanent_attribute_name = data["permanentAttributeName"]
     form_data = Rack::Utils.parse_nested_query(data["formData"])
     params = form_data.deep_merge(data["params"] || {})
@@ -31,9 +30,10 @@ class StimulusReflex::Channel < StimulusReflex.configuration.parent_channel.cons
     begin
       begin
         reflex_class = reflex_name.constantize.tap { |klass| raise ArgumentError.new("#{reflex_name} is not a StimulusReflex::Reflex") unless is_reflex?(klass) }
-        reflex = reflex_class.new(self,
+        reflex = reflex_class.new(
+          self,
           url: url,
-          element: element,
+          data: data,
           selectors: selectors,
           method_name: method_name,
           params: params,
@@ -43,7 +43,8 @@ class StimulusReflex::Channel < StimulusReflex.configuration.parent_channel.cons
             xpath_element: data["xpathElement"],
             reflex_controller: data["reflexController"],
             permanent_attribute_name: permanent_attribute_name
-          })
+          }
+        )
         delegate_call_to_reflex reflex, method_name, arguments
       rescue => invoke_error
         message = exception_message_with_backtrace(invoke_error)

--- a/javascript/attributes.js
+++ b/javascript/attributes.js
@@ -1,4 +1,7 @@
 import reflexes from './reflexes'
+import { elementToXPath, XPathToArray } from './utils'
+import Debug from './debug'
+// import Deprecate from './deprecate'
 
 const multipleInstances = element => {
   if (['checkbox', 'radio'].includes(element.type)) {
@@ -67,22 +70,59 @@ export const extractElementAttributes = element => {
   return attrs
 }
 
-// Extracts the dataset of an element and combines it with the data attributes from all parents if requested.
+// Extracts the dataset of an element and combines it with the data attributes from all specified tokens
 //
 export const extractElementDataset = element => {
-  let attrs = extractDataAttributes(element) || {}
+  let elements = [element]
+  const xPath = elementToXPath(element)
   const dataset = element.attributes[reflexes.app.schema.reflexDatasetAttribute]
+  const tokens = (dataset && dataset.value.split(' ')) || []
 
-  if (dataset && dataset.value === 'combined') {
-    let parent = element.parentElement
-
-    while (parent) {
-      attrs = { ...extractDataAttributes(parent), ...attrs }
-      parent = parent.parentElement
+  tokens.forEach(token => {
+    try {
+      switch (token) {
+        case 'combined':
+          // uncomment when SR#438 is merged
+          // if (Deprecate.enabled) console.warn("In the next version of StimulusReflex, the 'combined' option to data-reflex-dataset will become 'ancestors'.")
+          elements = [
+            ...elements,
+            ...XPathToArray(`${xPath}/ancestor::*`, true)
+          ]
+          break
+        case 'ancestors':
+          elements = [
+            ...elements,
+            ...XPathToArray(`${xPath}/ancestor::*`, true)
+          ]
+          break
+        case 'parent':
+          elements = [...elements, ...XPathToArray(`${xPath}/parent::*`)]
+          break
+        case 'siblings':
+          elements = [
+            ...elements,
+            ...XPathToArray(
+              `${xPath}/preceding-sibling::*|${xPath}/following-sibling::*`
+            )
+          ]
+          break
+        case 'children':
+          elements = [...elements, ...XPathToArray(`${xPath}/child::*`)]
+          break
+        case 'descendants':
+          elements = [...elements, ...XPathToArray(`${xPath}/descendant::*`)]
+          break
+        default:
+          elements = [...elements, ...XPathToArray(token)]
+      }
+    } catch (error) {
+      if (Debug.enabled) console.error(error)
     }
-  }
+  })
 
-  return attrs
+  return elements.reduce((acc, ele) => {
+    return { ...extractDataAttributes(ele), ...acc }
+  }, {})
 }
 
 // Extracts all data attributes from a DOM element.

--- a/javascript/attributes.js
+++ b/javascript/attributes.js
@@ -1,5 +1,4 @@
-import { defaultSchema } from './schema'
-import Debug from './debug'
+import reflexes from './reflexes'
 
 const multipleInstances = element => {
   if (['checkbox', 'radio'].includes(element.type)) {
@@ -70,9 +69,9 @@ export const extractElementAttributes = element => {
 
 // Extracts the dataset of an element and combines it with the data attributes from all parents if requested.
 //
-export const extractElementDataset = (element, datasetAttribute = null) => {
+export const extractElementDataset = element => {
   let attrs = extractDataAttributes(element) || {}
-  const dataset = datasetAttribute && element.attributes[datasetAttribute]
+  const dataset = element.attributes[reflexes.app.schema.reflexDatasetAttribute]
 
   if (dataset && dataset.value === 'combined') {
     let parent = element.parentElement

--- a/javascript/attributes.js
+++ b/javascript/attributes.js
@@ -140,3 +140,27 @@ export const extractDataAttributes = element => {
 
   return attrs
 }
+
+// Extracts all targets from a controller element.
+// Reflex targets are later available in the triggered reflex class
+//
+export const extractTargets = (controllerElement, schema) => {
+  let targets = {}
+
+  const targetElements = controllerElement.querySelectorAll(
+    `[${schema.reflexTargetAttribute}]`
+  )
+
+  targetElements.forEach(target => {
+    const targetName = target.dataset.reflexTarget.split('.')[1]
+
+    targets[targetName] = {
+      selector: elementToXPath(target),
+      name: targetName,
+      dataset: extractElementDataset(target, schema.reflexDatasetAttribute),
+      attrs: extractElementAttributes(target)
+    }
+  })
+
+  return targets
+}

--- a/javascript/attributes.js
+++ b/javascript/attributes.js
@@ -113,7 +113,7 @@ export const extractElementDataset = element => {
           elements = [...elements, ...XPathToArray(`${xPath}/descendant::*`)]
           break
         default:
-          elements = [...elements, ...XPathToArray(token)]
+          elements = [...elements, ...document.querySelectorAll(token)]
       }
     } catch (error) {
       if (Debug.enabled) console.error(error)

--- a/javascript/schema.js
+++ b/javascript/schema.js
@@ -2,5 +2,6 @@ export const defaultSchema = {
   reflexAttribute: 'data-reflex',
   reflexPermanentAttribute: 'data-reflex-permanent',
   reflexRootAttribute: 'data-reflex-root',
-  reflexDatasetAttribute: 'data-reflex-dataset'
+  reflexDatasetAttribute: 'data-reflex-dataset',
+  reflexTargetAttribute: 'data-reflex-target'
 }

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -12,7 +12,8 @@ import {
 import {
   attributeValues,
   extractElementAttributes,
-  extractElementDataset
+  extractElementDataset,
+  extractTargets
 } from './attributes'
 import Log from './log'
 import Debug from './debug'
@@ -127,6 +128,7 @@ const register = (controller, options = {}) => {
       if (typeof selectors === 'string') selectors = [selectors]
       const resolveLate = options['resolveLate'] || false
       const dataset = extractElementDataset(reflexElement)
+      const targets = extractTargets(this.element, reflexes.app.schema)
       const xpathController = elementToXPath(controllerElement)
       const xpathElement = elementToXPath(reflexElement)
       const data = {
@@ -135,6 +137,7 @@ const register = (controller, options = {}) => {
         url,
         attrs,
         dataset,
+        targets,
         selectors,
         reflexId,
         resolveLate,

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -126,8 +126,7 @@ const register = (controller, options = {}) => {
       let selectors = options['selectors'] || getReflexRoots(reflexElement)
       if (typeof selectors === 'string') selectors = [selectors]
       const resolveLate = options['resolveLate'] || false
-      const datasetAttribute = reflexes.app.schema.reflexDatasetAttribute
-      const dataset = extractElementDataset(reflexElement, datasetAttribute)
+      const dataset = extractElementDataset(reflexElement)
       const xpathController = elementToXPath(controllerElement)
       const xpathElement = elementToXPath(reflexElement)
       const data = {

--- a/javascript/utils.js
+++ b/javascript/utils.js
@@ -112,3 +112,21 @@ export const XPathToElement = xpath => {
     null
   ).singleNodeValue
 }
+
+export const XPathToArray = (xpath, reverse = false) => {
+  const snapshotList = document.evaluate(
+    xpath,
+    document,
+    null,
+    XPathResult.ORDERED_NODE_SNAPSHOT_TYPE,
+    null
+  )
+
+  const snapshots = []
+
+  for (let i = 0; i < snapshotList.snapshotLength; i++) {
+    snapshots.push(snapshotList.snapshotItem(i))
+  }
+
+  return reverse ? snapshots.reverse() : snapshots
+}

--- a/lib/stimulus_reflex/element.rb
+++ b/lib/stimulus_reflex/element.rb
@@ -34,7 +34,7 @@ class StimulusReflex::Element < OpenStruct
   def method_missing(method_name, *arguments, &block)
     if cable_ready.respond_to?(method_name)
       xpath = selector ? selector.starts_with?("//") : false
-      args = { selector: selector, xpath: xpath }.merge(arguments.first.to_h)
+      args = {selector: selector, xpath: xpath}.merge(arguments.first.to_h)
 
       cable_ready.send(method_name.to_sym, args)
 

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -8,7 +8,7 @@ class StimulusReflex::Reflex
   include ActionView::Helpers::TagHelper
 
   attr_accessor :payload
-  attr_reader :cable_ready, :channel, :url, :element, :selectors, :method_name, :broadcaster, :client_attributes, :logger
+  attr_reader :cable_ready, :channel, :url, :element, :data, :selectors, :method_name, :broadcaster, :client_attributes, :logger
 
   alias_method :action_name, :method_name # for compatibility with controller libraries like Pundit that expect an action name
 
@@ -17,7 +17,7 @@ class StimulusReflex::Reflex
   delegate :broadcast, :broadcast_message, to: :broadcaster
   delegate :reflex_id, :reflex_controller, :xpath_controller, :xpath_element, :permanent_attribute_name, to: :client_attributes
 
-  def initialize(channel, url: nil, element: nil, selectors: [], method_name: nil, params: {}, client_attributes: {})
+  def initialize(channel, url: nil, data: nil, selectors: [], method_name: nil, params: {}, client_attributes: {})
     if is_a? CableReady::Broadcaster
       message = <<~MSG
 
@@ -31,7 +31,7 @@ class StimulusReflex::Reflex
 
     @channel = channel
     @url = url
-    @element = element
+    @data = data
     @selectors = selectors
     @method_name = method_name
     @params = params
@@ -40,6 +40,13 @@ class StimulusReflex::Reflex
     @client_attributes = ClientAttributes.new(client_attributes)
     @cable_ready = StimulusReflex::CableReadyChannels.new(stream_name)
     @payload = {}
+
+    @element = StimulusReflex::Element.new(
+      attrs: data["attrs"],
+      dataset: data["dataset"],
+      selector: data["xpathElement"],
+      cable_ready: @cable_ready
+    )
     self.params
   end
 

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -112,6 +112,10 @@ class StimulusReflex::Reflex
     end
   end
 
+  def controller_element
+    @controller_element ||= StimulusReflex::Element.new(selector: xpath_controller, cable_ready: @cable_ready)
+  end
+
   def controller?
     !!defined? @controller
   end


### PR DESCRIPTION
# Type of PR

Feature

## Description

This PR is part of a bigger story. This work is based on #478  and #489.

With this PR we allow to declare DOM nodes as StimulusReflex targets so you are able to access and operate on them with CableRady operations in your reflexes. 

Here is an example:

```html
<div data-controller="folder" data-folder-id="42">
  <input type="text" data-reflex-target="folder.input">
  <button data-reflex="click->Folder#search" data-reflex-dataset="combined">Search</button>

  <span id="count" data-reflex-target="folder.count"></span>

  <div id="results" data-reflex-target="folder.results"></div>
</div>
```

```ruby
class FolderReflex < StimulusReflex::Reflex
  def search
    folder = Folder.find_by(id: element.dataset.folder_id)

    controller_element.append(html: '<div id="spinner"></div>')
    element.set_attribute(name: 'value', value: '').set_focus.update

    results = folder.search(input_target.value)

    count_target.text_content(text: results.count)
    results_target.inner_html(html: render(partial: "folders/results", locals: { results: results }))
 
    cable_ready.remove(selector: '#spinner')

    morph :nothing
  end
end
```

## Why should this be added

Targets are well known to Stimulus developers. This PR applies the same target-concept to reflexes. This, in combination with #489, enables a whole new world on how you write your CableReady operations while writing clean, super understandable and easy-to-look-at code.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update
