### PR TITLE
Log the full exception trace

### DIFF
--- a/app/channels/stimulus_reflex/channel.rb
+++ b/app/channels/stimulus_reflex/channel.rb
@@ -24,14 +24,14 @@ class StimulusReflex::Channel < StimulusReflex.configuration.parent_channel.cons
         delegate_call_to_reflex reflex
       rescue => exception
         error = exception_with_backtrace(exception)
-        body = "Reflex #{reflex_data.target} failed: #{error[:message]} [#{reflex_data.url}]\n#{error[:stack]}"
+        error_message = "\e[31mReflex #{reflex_data.target} failed: #{error[:message]} [#{reflex_data.url}]\e[0m\n#{error[:stack]}"
 
         if reflex
           reflex.rescue_with_handler(exception)
-          puts "\e[31m#{body}\e[0m"
+          puts error_message
           reflex.broadcast_message subject: "error", data: data, error: exception
         else
-          puts "\e[31m#{body}\e[0m"
+          puts error_message
 
           if body.to_s.include? "No route matches"
             initializer_path = Rails.root.join("config", "initializers", "stimulus_reflex.rb")
@@ -66,8 +66,7 @@ class StimulusReflex::Channel < StimulusReflex.configuration.parent_channel.cons
           reflex.rescue_with_handler(exception)
           error = exception_with_backtrace(exception)
           reflex.broadcast_message subject: "error", data: data, error: exception
-          body = "Reflex failed to re-render: #{error[:message]} [#{reflex_data.url}]\n#{error[:stack]}"
-          puts "\e[31m#{body}\e[0m"
+          puts "\e[31mReflex failed to re-render: #{error[:message]} [#{reflex_data.url}]\e[0m\n#{error[:stack]}"
         end
       end
     ensure
@@ -108,14 +107,12 @@ class StimulusReflex::Channel < StimulusReflex.configuration.parent_channel.cons
     store.commit_session reflex.request, reflex.controller.response
   rescue => exception
     error = exception_with_backtrace(exception)
-    output = "Failed to commit session! #{error[:message]}\n#{error[:backtrace]}"
-    puts "\e[31m#{output}\e[0m"
+    puts "\e[31mFailed to commit session! #{error[:message]}\e[0m\n#{error[:backtrace]}"
   end
 
   def report_failed_basic_auth(reflex)
     if reflex.controller.response.status == 401
-      message = "Reflex failed to process controller action \"#{reflex.controller.class}##{reflex.controller.action_name}\" due to HTTP basic auth. Consider adding \"unless: -> { @stimulus_reflex }\" to the before_action or method responible for authentication."
-      puts "\e[31m#{message}\e[0m"
+      puts "\e[31mReflex failed to process controller action \"#{reflex.controller.class}##{reflex.controller.action_name}\" due to HTTP basic auth. Consider adding \"unless: -> { @stimulus_reflex }\" to the before_action or method responible for authentication.\e[0m"
     end
   end
 

--- a/lib/stimulus_reflex/broadcasters/broadcaster.rb
+++ b/lib/stimulus_reflex/broadcasters/broadcaster.rb
@@ -23,8 +23,7 @@ module StimulusReflex
       false
     end
 
-    def broadcast_message(subject:, body: nil, data: {}, error: nil)
-      logger.error "\e[31m#{body}\e[0m" if subject == "error"
+    def broadcast_message(subject:, data: {}, error: nil)
       operations << ["document", :dispatch_event]
       cable_ready.dispatch_event(
         name: "stimulus-reflex:server-message",

--- a/lib/stimulus_reflex/utils/sanity_checker.rb
+++ b/lib/stimulus_reflex/utils/sanity_checker.rb
@@ -14,6 +14,7 @@ class StimulusReflex::SanityChecker
       instance = new
       instance.check_caching_enabled
       instance.check_javascript_package_version
+      instance.check_default_url_config
       instance.check_new_version_available
     end
 
@@ -43,6 +44,19 @@ class StimulusReflex::SanityChecker
       warn_and_exit <<~WARN
         StimulusReflex requires caching to be enabled. Caching allows the session to be modified during ActionCable requests.
         But your config.cache_store is set to :null_store, so it won't work.
+      WARN
+    end
+  end
+
+  def check_default_url_config
+    unless default_url_config_set?
+      warn_and_exit <<~WARN
+        StimulusReflex strongly suggests that you set default_url_options in your environment files.
+        Otherwise, ActionController and ActionMailer will default to example.com when rendering route helpers.
+        You can set your URL options in config/environments/#{Rails.env}.rb
+          config.action_controller.default_url_options = {host: "localhost", port: 3000}
+          config.action_mailer.default_url_options = {host: "localhost", port: 3000}
+        Please update every environment with the appropriate URL. Typically, no port is necessary in production.
       WARN
     end
   end
@@ -95,6 +109,10 @@ class StimulusReflex::SanityChecker
 
   def not_null_store?
     Rails.application.config.cache_store != :null_store
+  end
+
+  def default_url_config_set?
+    Rails.application.config.action_controller.default_url_options
   end
 
   def javascript_version_matches?


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Enhancement

## Description

Render the entire stack trace instead of just the top level error.

## Why should this be added

Simply put, this makes debugging a lot easier especially for exceptions caused by ViewComponents. I've often run into cases where the exception comes deep from within Rails and without the full trace, it's hard to know what part of your code tripped it.

If it'd be better to gate this behaviour change behind an option or something, I'd be happy to make the change (I'd just need to know how best to handle it).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update
