### PR TITLE
Stop adding whitespace when parsing our html

### DIFF
--- a/lib/stimulus_reflex/broadcasters/broadcaster.rb
+++ b/lib/stimulus_reflex/broadcasters/broadcaster.rb
@@ -5,6 +5,9 @@ module StimulusReflex
     attr_reader :reflex, :logger, :operations
     delegate :cable_ready, :permanent_attribute_name, :payload, to: :reflex
 
+    DEFAULT_HTML_WITHOUT_FORMAT = Nokogiri::XML::Node::SaveOptions::DEFAULT_HTML &
+      ~Nokogiri::XML::Node::SaveOptions::FORMAT
+
     def initialize(reflex)
       @reflex = reflex
       @logger = Rails.logger if defined?(Rails.logger)

--- a/lib/stimulus_reflex/broadcasters/page_broadcaster.rb
+++ b/lib/stimulus_reflex/broadcasters/page_broadcaster.rb
@@ -12,7 +12,7 @@ module StimulusReflex
       selectors = selectors.select { |s| document.css(s).present? }
       selectors.each do |selector|
         operations << [selector, :morph]
-        html = document.css(selector).inner_html
+        html = document.css(selector).inner_html(save_with: Broadcaster::DEFAULT_HTML_WITHOUT_FORMAT)
         cable_ready.morph(
           selector: selector,
           html: html,

--- a/lib/stimulus_reflex/broadcasters/selector_broadcaster.rb
+++ b/lib/stimulus_reflex/broadcasters/selector_broadcaster.rb
@@ -17,7 +17,7 @@ module StimulusReflex
             operations << [selector, :morph]
             cable_ready.morph(
               selector: selector,
-              html: match.inner_html,
+              html: match.inner_html(save_with: Broadcaster::DEFAULT_HTML_WITHOUT_FORMAT),
               payload: payload,
               children_only: true,
               permanent_attribute_name: permanent_attribute_name,

--- a/test/broadcasters/page_broadcaster_test.rb
+++ b/test/broadcasters/page_broadcaster_test.rb
@@ -12,7 +12,7 @@ class StimulusReflex::PageBroadcasterTest < StimulusReflex::BroadcasterTestCase
   test "performs a page morph on body" do
     class << @reflex.controller.response
       def body
-        "<html><head></head><body>New Content</body></html>"
+        "<html><head></head><body><div>New Content</div><div>Another Content</div></body></html>"
       end
     end
 
@@ -24,7 +24,7 @@ class StimulusReflex::PageBroadcasterTest < StimulusReflex::BroadcasterTestCase
         "morph" => [
           {
             "selector" => "body",
-            "html" => "New Content",
+            "html" => "<div>New Content</div><div>Another Content</div>",
             "payload" => {},
             "childrenOnly" => true,
             "permanentAttributeName" => nil,

--- a/test/broadcasters/selector_broadcaster_test.rb
+++ b/test/broadcasters/selector_broadcaster_test.rb
@@ -1,59 +1,61 @@
 # frozen_string_literal: true
 
-# require_relative "broadcaster_test_case"
+require_relative "broadcaster_test_case"
 
-# class StimulusReflex::SelectorBroadcasterTest < StimulusReflex::BroadcasterTestCase
-# test "morphs the contents of an element if the selector(s) are present in both original and morphed html fragments" do
-# broadcaster = StimulusReflex::SelectorBroadcaster.new(@reflex)
-# broadcaster.append_morph("#foo", "<div id=\"foo\"><span>bar</span></div>")
+module StimulusReflex
+  class SelectorBroadcasterTest < StimulusReflex::BroadcasterTestCase
+    test "morphs the contents of an element if the selector(s) are present in both original and morphed html fragments" do
+      broadcaster = StimulusReflex::SelectorBroadcaster.new(@reflex)
+      broadcaster.append_morph("#foo", '<div id="foo"><span>bar</span></div>')
 
-# expected = {
-# "cableReady" => true,
-# "operations" => {
-# "morph" => [
-# {
-# "selector" => "#foo",
-# "html" => "<span>bar</span>",
-# "childrenOnly" => true,
-# "permanentAttributeName" => nil,
-# "stimulusReflex" => {
-# "payload" => {},
-# "some" => :data,
-# "morph" => :selector
-# }
-# }
-# ]
-# }
-# }
+      expected = {
+        "cableReady" => true,
+        "operations" => {
+          "morph" => [
+            {
+              "selector" => "#foo",
+              "html" => "<span>bar</span>",
+              "payload" => {},
+              "childrenOnly" => true,
+              "permanentAttributeName" => nil,
+              "stimulusReflex" => {
+                "some" => :data,
+                "morph" => :selector
+              }
+            }
+          ]
+        }
+      }
 
-# assert_broadcast_on @reflex.stream_name, expected do
-# broadcaster.broadcast nil, some: :data
-# end
-# end
+      assert_broadcast_on @reflex.stream_name, expected do
+        broadcaster.broadcast nil, some: :data
+      end
+    end
 
-# test "replaces the contents of an element and ignores permanent-attributes if the selector(s) aren't present in the replacing html fragment" do
-# broadcaster = StimulusReflex::SelectorBroadcaster.new(@reflex)
-# broadcaster.append_morph("#foo", "<div id=\"baz\"><span>bar</span></div>")
+    test "replaces the contents of an element and ignores permanent-attributes if the selector(s) aren't present in the replacing html fragment" do
+      broadcaster = StimulusReflex::SelectorBroadcaster.new(@reflex)
+      broadcaster.append_morph("#foo", '<div id="baz"><span>bar</span></div>')
 
-# expected = {
-# "cableReady" => true,
-# "operations" => {
-# "innerHtml" => [
-# {
-# "selector" => "#foo",
-# "html" => "<div id=\"baz\"><span>bar</span></div>",
-# "stimulusReflex" => {
-# "payload" => {},
-# "some" => :data,
-# "morph" => :selector
-# }
-# }
-# ]
-# }
-# }
+      expected = {
+        "cableReady" => true,
+        "operations" => {
+          "innerHtml" => [
+            {
+              "selector" => "#foo",
+              "html" => '<div id="baz"><span>bar</span></div>',
+              "payload" => {},
+              "stimulusReflex" => {
+                "some" => :data,
+                "morph" => :selector
+              }
+            }
+          ]
+        }
+      }
 
-# assert_broadcast_on @reflex.stream_name, expected do
-# broadcaster.broadcast nil, some: :data
-# end
-# end
-# end
+      assert_broadcast_on @reflex.stream_name, expected do
+        broadcaster.broadcast nil, some: :data
+      end
+    end
+  end
+end

--- a/test/broadcasters/selector_broadcaster_test.rb
+++ b/test/broadcasters/selector_broadcaster_test.rb
@@ -19,9 +19,10 @@ module StimulusReflex
               "childrenOnly" => true,
               "permanentAttributeName" => nil,
               "stimulusReflex" => {
-                "some" => :data,
-                "morph" => :selector
-              }
+                "some" => "data",
+                "morph" => "selector"
+              },
+              "reflexId" => "666"
             }
           ]
         }
@@ -45,9 +46,10 @@ module StimulusReflex
               "html" => '<div id="baz"><span>bar</span></div>',
               "payload" => {},
               "stimulusReflex" => {
-                "some" => :data,
-                "morph" => :selector
-              }
+                "some" => "data",
+                "morph" => "selector"
+              },
+              "reflexId" => "666"
             }
           ]
         }

--- a/test/broadcasters/selector_broadcaster_test.rb
+++ b/test/broadcasters/selector_broadcaster_test.rb
@@ -6,7 +6,7 @@ module StimulusReflex
   class SelectorBroadcasterTest < StimulusReflex::BroadcasterTestCase
     test "morphs the contents of an element if the selector(s) are present in both original and morphed html fragments" do
       broadcaster = StimulusReflex::SelectorBroadcaster.new(@reflex)
-      broadcaster.append_morph("#foo", '<div id="foo"><span>bar</span></div>')
+      broadcaster.append_morph("#foo", '<div id="foo"><div>bar</div><div>baz</div></div>')
 
       expected = {
         "cableReady" => true,
@@ -14,7 +14,7 @@ module StimulusReflex
           "morph" => [
             {
               "selector" => "#foo",
-              "html" => "<span>bar</span>",
+              "html" => "<div>bar</div><div>baz</div>",
               "payload" => {},
               "childrenOnly" => true,
               "permanentAttributeName" => nil,


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bug fix.

## Description

As shown by @shepmaster on #487, we were adding extra whitespace
to the DOM when parsing. That was causing morphdom to do several
replaces on the first page load since it was comparing a page without
the whitespace and the "new" page with all the whitespaces added.

The solution was just saying for Nokogiri to use the DEFAULT_HTML
but without doing the FORMAT part.

Fixes #487

## Why should this be added

With the extra whitespace being added, we were re-rendering several parts of the DOM without it really being different. It was unnecessary re-renders and, for a more specific issue, it was causing the browser to close its autocomplete on a field cause it was replacing the field with a new one even though they were still the exact same DOM (but with extra whitespace).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update
