### PR TITLE
Always pick up instance variables when accessing controller

### DIFF
--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -98,11 +98,12 @@ class StimulusReflex::Reflex
     @controller ||= begin
       controller_class.new.tap do |c|
         c.instance_variable_set :"@stimulus_reflex", true
-        instance_variables.each { |name| c.instance_variable_set name, instance_variable_get(name) }
         c.set_request! request
         c.set_response! controller_class.make_response!(request)
       end
     end
+    instance_variables.each { |name| @controller.instance_variable_set name, instance_variable_get(name) }
+    @controller
   end
 
   def controller?


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bug fix

## Description

Changes `Reflex#controller` so that it adds any ivars to the controller instance, even if it's been previously memoized.

Fixes #471

## Why should this be added

Since `controller` is memoized, if it is called in a `before_reflex` callback, any instance variables set in the main Reflex method will not be present in the controller when the page is rendered.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update