### PR TITLE
Prevent install script from choking on magic comments via hard-coded line numbers

### DIFF
--- a/lib/tasks/stimulus_reflex/install.rake
+++ b/lib/tasks/stimulus_reflex/install.rake
@@ -52,7 +52,8 @@ namespace :stimulus_reflex do
     filepath = Rails.root.join("config/environments/development.rb")
     lines = File.open(filepath, "r") { |f| f.readlines }
     unless lines.find { |line| line.include?("config.session_store") }
-      lines.insert 3, "  config.session_store :cache_store\n\n"
+      matches = lines.select { |line| line =~ /\A(Rails.application.configure do)/ }
+      lines.insert lines.index(matches.last).to_i + 1, "  config.session_store :cache_store\n\n"
       File.open(filepath, "w") { |f| f.write lines.join }
     end
 


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bug fix

## Description

Modify install script to add line on the first line after the `Rails.application.configure` block begins.

Fixes #429

## Why should this be added

Hard-coded line numbers could break if a magic comment is added to the file.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update