### PR TITLE
render_collection

### DIFF
--- a/lib/stimulus_reflex/broadcasters/selector_broadcaster.rb
+++ b/lib/stimulus_reflex/broadcasters/selector_broadcaster.rb
@@ -8,7 +8,7 @@ module StimulusReflex
         updates = selectors.is_a?(Hash) ? selectors : Hash[selectors, html]
         updates.each do |key, value|
           html = reflex.render(key) if key.is_a?(ActiveRecord::Base) && value.nil?
-          html = reflex.wrap(reflex.render(key), key) if key.is_a?(ActiveRecord::Relation) && value.nil?
+          html = reflex.render_collection(key) if key.is_a?(ActiveRecord::Relation) && value.nil?
           fragment = Nokogiri::HTML.fragment(html&.to_s || "")
 
           selector = key.is_a?(ActiveRecord::Base) || key.is_a?(ActiveRecord::Relation) ? reflex.dom_id(key) : key

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -158,4 +158,18 @@ class StimulusReflex::Reflex
     content = render(resource) unless content
     tag.div(content.html_safe, id: dom_id(resource, hash: ""))
   end
+
+  def wrap(content, resource)
+    puts "DEPRECIATION WARNING! This method has been renamed to render_collection, and the method signature is reversed:"
+    puts
+    puts "render_collection(resource, content)"
+    puts
+    puts "Or, if you were calling wrap(render(@posts), @posts), you can now just call:"
+    puts
+    puts "render_collection(@posts)"
+    puts
+    puts "We're making this message as long and obnoxious as possible because soon, we're going to exit if you're still calling wrap."
+    render_collection(resource, content)
+  end
+
 end

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -153,8 +153,12 @@ class StimulusReflex::Reflex
   # morphdom needs content to be wrapped in an element with the same id when children_only: true
   # Oddly, it doesn't matter if the target element is a div! See: https://docs.stimulusreflex.com/appendices/troubleshooting#different-element-type-altogether-who-cares-so-long-as-the-css-selector-matches
   # Used internally to allow automatic partial collection rendering, but also useful to library users
-  # eg. `morph dom_id(@posts), wrap(render(@posts), @posts)`
-  def wrap(content, resource)
+  # eg. `morph dom_id(@posts), render_collection(@posts)`
+  def render_collection(content, resource = nil)
+    if resource.nil?
+      resource = content
+      content = render(content)
+    end
     tag.div(content.html_safe, id: dom_id(resource, hash: ""))
   end
 end

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -155,7 +155,7 @@ class StimulusReflex::Reflex
   # Used internally to allow automatic partial collection rendering, but also useful to library users
   # eg. `morph dom_id(@posts), render_collection(@posts)`
   def render_collection(resource, content = nil)
-    content = render(resource) unless content
+    content ||= render(resource)
     tag.div(content.html_safe, id: dom_id(resource, hash: ""))
   end
 
@@ -171,5 +171,4 @@ class StimulusReflex::Reflex
     puts "We're making this message as long and obnoxious as possible because soon, we're going to exit if you're still calling wrap."
     render_collection(resource, content)
   end
-
 end

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -158,17 +158,4 @@ class StimulusReflex::Reflex
     content ||= render(resource)
     tag.div(content.html_safe, id: dom_id(resource, hash: ""))
   end
-
-  def wrap(content, resource)
-    puts "DEPRECIATION WARNING! This method has been renamed to render_collection, and the method signature is reversed:"
-    puts
-    puts "render_collection(resource, content)"
-    puts
-    puts "Or, if you were calling wrap(render(@posts), @posts), you can now just call:"
-    puts
-    puts "render_collection(@posts)"
-    puts
-    puts "We're making this message as long and obnoxious as possible because soon, we're going to exit if you're still calling wrap."
-    render_collection(resource, content)
-  end
 end

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -154,11 +154,8 @@ class StimulusReflex::Reflex
   # Oddly, it doesn't matter if the target element is a div! See: https://docs.stimulusreflex.com/appendices/troubleshooting#different-element-type-altogether-who-cares-so-long-as-the-css-selector-matches
   # Used internally to allow automatic partial collection rendering, but also useful to library users
   # eg. `morph dom_id(@posts), render_collection(@posts)`
-  def render_collection(content, resource = nil)
-    if resource.nil?
-      resource = content
-      content = render(content)
-    end
+  def render_collection(resource, content = nil)
+    content = render(resource) unless content
     tag.div(content.html_safe, id: dom_id(resource, hash: ""))
   end
 end


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Enhancement

## Description

Renames the `Reflex#wrap` method to `render_collection`.

Render collection method signature now includes a single resource passed, so:

`wrap(render(@posts), @posts)` now becomes `render_collection(@posts)`

I created a temporary `wrap` method that issues a stern deprecation warning, even though technically `wrap` has never been part of a shipped release. It issues a warning that is hard to ignore and then passes to `render_collection`. We'll remove this before shipping the final v3.5.

## Why should this be added

I strongly suspect that 90% of `wrap` calls will actually receive the same parameter essentially twice. You can still call it the old way, but if you cut through to general intent, this is clearly a superior name and mechanism.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update