### PR TITLE
Move object_with_indifferent_access to ReflexData

### DIFF
--- a/app/channels/stimulus_reflex/channel.rb
+++ b/app/channels/stimulus_reflex/channel.rb
@@ -80,12 +80,6 @@ class StimulusReflex::Channel < StimulusReflex.configuration.parent_channel.cons
 
   private
 
-  def object_with_indifferent_access(object)
-    return object.with_indifferent_access if object.respond_to?(:with_indifferent_access)
-    object.map! { |obj| object_with_indifferent_access obj } if object.is_a?(Array)
-    object
-  end
-
   def delegate_call_to_reflex(reflex)
     method_name = reflex_data.method_name
     arguments = reflex_data.arguments

--- a/lib/stimulus_reflex/reflex_data.rb
+++ b/lib/stimulus_reflex/reflex_data.rb
@@ -64,4 +64,12 @@ class StimulusReflex::ReflexData
   def reflex_controller
     data["reflexController"]
   end
+
+  private
+
+  def object_with_indifferent_access(object)
+    return object.with_indifferent_access if object.respond_to?(:with_indifferent_access)
+    object.map! { |obj| object_with_indifferent_access obj } if object.is_a?(Array)
+    object
+  end
 end


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)
Bug fix

## Description

When code was refactored into new class called ReflexData in 680efc1, the `object_with_indifferent_access` method was forgotten. It subsequently fails when mapping over `data["args"]` with the error:

`Reflex Users#tag failed: undefined method 'object_with_indifferent_access' for #<StimulusReflex::ReflexData:0x00007fa737e58c98>`

## Why should this be added

It should work when mapping over arguments.