### PR TITLE
convert symbol keys, ensure fragment html exists

### DIFF
--- a/lib/stimulus_reflex/broadcasters/selector_broadcaster.rb
+++ b/lib/stimulus_reflex/broadcasters/selector_broadcaster.rb
@@ -9,9 +9,9 @@ module StimulusReflex
         updates.each do |key, value|
           html = reflex.render(key) if key.is_a?(ActiveRecord::Base) && value.nil?
           html = reflex.render_collection(key) if key.is_a?(ActiveRecord::Relation) && value.nil?
-          fragment = Nokogiri::HTML.fragment(html&.to_s || "")
-
-          selector = key.is_a?(ActiveRecord::Base) || key.is_a?(ActiveRecord::Relation) ? reflex.dom_id(key) : key
+          html ||= value
+          fragment = Nokogiri::HTML.fragment(html.to_s)
+          selector = key.is_a?(ActiveRecord::Base) || key.is_a?(ActiveRecord::Relation) ? reflex.dom_id(key) : key.to_s
           match = fragment.at_css(selector)
           if match.present?
             operations << [selector, :morph]


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bug fix(es)

## Description

Symbol keys should not break debugging String refinement.
Hashes passed to `morph` should not be converted to `""` content value.

Fixes #502

## Why should this be added

Hash form is clearly under-utilized by SR core team. @pgaspar's issue led to me spotting a much stinkier problem. Thank-you!

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update