### PR TITLE
tab_id accessor

### DIFF
--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -155,6 +155,7 @@ const register = (controller, options = {}) => {
         target,
         args,
         url,
+        tabId,
         attrs,
         dataset,
         selectors,
@@ -263,6 +264,9 @@ const register = (controller, options = {}) => {
     }
   })
 }
+
+// Uniquely identify this browser tab in each Reflex
+const tabId = uuidv4()
 
 const useReflex = (controller, options = {}) => {
   register(controller, options)

--- a/lib/generators/stimulus_reflex/templates/app/reflexes/%file_name%_reflex.rb.tt
+++ b/lib/generators/stimulus_reflex/templates/app/reflexes/%file_name%_reflex.rb.tt
@@ -17,6 +17,7 @@ class <%= class_name %>Reflex < ApplicationReflex
   #     - unsigned  - use an unsigned Global ID to map dataset attribute to a model  eg. element.unsigned[:foo]
   #   - cable_ready - a special cable_ready that can broadcast to the current visitor (no brackets needed)
   #   - reflex_id   - a UUIDv4 that uniquely identies each Reflex
+  #   - tab_id      - a UUIDv4 that uniquely identifies the browser tab
   #
   # Example:
   #

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-ClientAttributes = Struct.new(:reflex_id, :reflex_controller, :xpath_controller, :xpath_element, :permanent_attribute_name, keyword_init: true)
+ClientAttributes = Struct.new(:reflex_id, :tab_id, :reflex_controller, :xpath_controller, :xpath_element, :permanent_attribute_name, keyword_init: true)
 
 class StimulusReflex::Reflex
   include ActiveSupport::Rescuable
@@ -15,7 +15,7 @@ class StimulusReflex::Reflex
   delegate :connection, :stream_name, to: :channel
   delegate :controller_class, :flash, :session, to: :request
   delegate :broadcast, :broadcast_message, to: :broadcaster
-  delegate :reflex_id, :reflex_controller, :xpath_controller, :xpath_element, :permanent_attribute_name, to: :client_attributes
+  delegate :reflex_id, :tab_id, :reflex_controller, :xpath_controller, :xpath_element, :permanent_attribute_name, to: :client_attributes
 
   def initialize(channel, url: nil, element: nil, selectors: [], method_name: nil, params: {}, client_attributes: {})
     if is_a? CableReady::Broadcaster

--- a/lib/stimulus_reflex/reflex_data.rb
+++ b/lib/stimulus_reflex/reflex_data.rb
@@ -53,6 +53,10 @@ class StimulusReflex::ReflexData
     data["reflexId"]
   end
 
+  def tab_id
+    data["tabId"]
+  end
+
   def xpath_controller
     data["xpathController"]
   end

--- a/lib/stimulus_reflex/reflex_factory.rb
+++ b/lib/stimulus_reflex/reflex_factory.rb
@@ -12,6 +12,7 @@ class StimulusReflex::ReflexFactory
         params: reflex_data.form_params,
         client_attributes: {
           reflex_id: reflex_data.reflex_id,
+          tab_id: reflex_data.tab_id,
           xpath_controller: reflex_data.xpath_controller,
           xpath_element: reflex_data.xpath_element,
           reflex_controller: reflex_data.reflex_controller,


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Enhancement

## Description

Reflex class gains a `tab_id` accessor to compliment `reflex_id`. It is a UUIDv4 that is generated every time SR is initialized, eg once per tab. Refreshes and different/duplicated tabs will have different values.

Part of the ClientAttributes struct.

Updated the generator template to reflect this new accessor.

## Why should this be added

Sometimes, I really wish that I had a way of uniquely identifying the browser tab which made a request without having to pack it into a data attribute. It's especially significant for an upcoming gem I'm working on.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update